### PR TITLE
feat: sort moderations panel by report count and creation date

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/moderations/admin/filterable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Moderations
+    module Admin
+      module Filterable
+        extend ActiveSupport::Concern
+
+        included do
+          include Decidim::Admin::Filterable
+
+          private
+
+          def base_query
+            collection
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -4,7 +4,9 @@ module Decidim
   module Admin
     # This controller allows admins to manage moderations in a participatory process.
     class ModerationsController < Decidim::Admin::ApplicationController
-      helper_method :moderations, :allowed_to?
+      include Decidim::Moderations::Admin::Filterable
+
+      helper_method :moderations, :allowed_to?, :query
 
       def index
         enforce_permission_to :read, :moderation
@@ -60,14 +62,23 @@ module Decidim
 
       private
 
-      def moderations
-        @moderations ||= begin
+      # Private: This method is used by the `Filterable` concern as the base query
+      #          without applying filtering and/or sorting options.
+      def collection
+        @collection ||= begin
           if params[:hidden]
             participatory_space_moderations.where.not(hidden_at: nil)
           else
             participatory_space_moderations.where(hidden_at: nil)
           end
         end
+      end
+
+      # Private: Returns a collection of `Moderation` filtered and/or sorted by
+      #          some criteria. The `filtered_collection` is provided by the
+      #          `Filterable` concern.
+      def moderations
+        @moderations ||= filtered_collection
       end
 
       def reportable

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -18,10 +18,10 @@
           <tr>
             <th><%= t("models.moderation.fields.reportable_id", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reportable_type", scope: "decidim.moderations") %></th>
-            <th><%= t("models.moderation.fields.report_count", scope: "decidim.moderations") %></th>
+            <th><%= sort_link(query, :report_count, t("models.moderation.fields.report_count", scope: "decidim.moderations")) %></th>
             <th><%= t("models.moderation.fields.reported_content_url", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reports", scope: "decidim.moderations") %></th>
-            <th><%= t("models.moderation.fields.created_at", scope: "decidim.moderations") %></th>
+            <th><%= sort_link(query, :created_at, t("models.moderation.fields.created_at", scope: "decidim.moderations")) %></th>
             <% if params[:hidden] %>
               <th><%= t("models.moderation.fields.hidden_at", scope: "decidim.moderations") %></th>
             <% end %>

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -50,7 +50,7 @@ shared_examples "manage moderations" do
     end
 
     it "user can sort by report count" do
-      moderations.each { |moderation| moderation.update(report_count: rand(1..5)) }
+      moderations.each_with_index { |moderation, index| moderation.update(report_count: index + 1) }
       moderations_ordered_by_report_count_asc = moderations.sort_by(&:report_count)
 
       within "table" do

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -48,6 +48,20 @@ shared_examples "manage moderations" do
       expect(page).to have_admin_callout("Resource successfully hidden")
       expect(page).to have_no_content(moderation.reportable.reported_content_url)
     end
+
+    it "user can sort by report count" do
+      moderations.each { |moderation| moderation.update(report_count: rand(1..5)) }
+      moderations_ordered_by_report_count_asc = moderations.sort_by(&:report_count)
+
+      within "table" do
+        click_link "Count"
+
+        all("tbody tr").each_with_index do |row, index|
+          reportable_id = moderations_ordered_by_report_count_asc[index].reportable.id
+          expect(row.find("td:first-child")).to have_content(reportable_id)
+        end
+      end
+    end
   end
 
   context "when listing hidden resources" do


### PR DESCRIPTION
#### :tophat: What? Why?

This adds sort options for the moderations table in the admin panel. Users can sort by report count and creation date (see screenshot below).

#### Testing

1. Visit the admin moderations panel.
1. Click either the report count or creation date headers.
1. The moderations should be sorted by that column in ascending order.
1. Click the same column to sort in descending order.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/106021/95748611-87eec080-0c9a-11eb-84bc-e7507b82f54c.png)