### PR TITLE
feat: add info to moderator email

### DIFF
--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -15,7 +15,7 @@ module Decidim
         @organization = user.organization
         @user = user
         @author = @report.moderation.reportable.try(:creator_identity) || @report.moderation.reportable.try(:author)
-        @content = { title: @report.moderation.reportable.try(:title), body: @report.moderation.reportable.try(:body) }.compact
+        @content = { title: @report.moderation.reportable.try(:title), body: @report.moderation.reportable.try(:body), id: @report.moderation.reportable.id }.compact
         subject = I18n.t("report.subject", scope: "decidim.reported_mailer")
         mail(to: user.email, subject: subject)
       end

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -17,7 +17,8 @@ module Decidim
         @author = @report.moderation.reportable.try(:creator_identity) || @report.moderation.reportable.try(:author)
         content_title = @report.moderation.reportable.try(:title)
         content_body = @report.moderation.reportable.try(:body)
-        @content = { title: content_title, body: content_body, id: @report.moderation.reportable.id }.compact
+        @content = { title: content_title, body: content_body }.compact
+        @content_id = @report.moderation.reportable.id
         @original_language = original_language_for(content_title) || original_language_for(content_body)
         subject = I18n.t("report.subject", scope: "decidim.reported_mailer")
         mail(to: user.email, subject: subject)

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -15,7 +15,10 @@ module Decidim
         @organization = user.organization
         @user = user
         @author = @report.moderation.reportable.try(:creator_identity) || @report.moderation.reportable.try(:author)
-        @content = { title: @report.moderation.reportable.try(:title), body: @report.moderation.reportable.try(:body), id: @report.moderation.reportable.id }.compact
+        content_title = @report.moderation.reportable.try(:title)
+        content_body = @report.moderation.reportable.try(:body)
+        @content = { title: content_title, body: content_body, id: @report.moderation.reportable.id }.compact
+        @original_language = original_language_for(content_title) || original_language_for(content_body)
         subject = I18n.t("report.subject", scope: "decidim.reported_mailer")
         mail(to: user.email, subject: subject)
       end
@@ -44,6 +47,13 @@ module Decidim
 
     def author_profile_url
       @author_profile_url ||= @author.is_a?(Decidim::UserBaseEntity) ? decidim.profile_url(@author.nickname, host: @organization.host) : nil
+    end
+
+    def original_language_for(field)
+      return if field.nil?
+      return field.except("machine_translations").keys.first if field.is_a?(Hash) && field.except("machine_translations").keys.count == 1
+
+      @organization.default_locale
     end
   end
 end

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -28,7 +28,7 @@
 <% end %>
 
 <% if @content.present? %>
-  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%= @content[:id] %>)</p>
+  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%= @content_id %>)</p>
   <blockquote>
     <h5><%= translated_attribute @content[:title] %></h5>
     <p><%= translated_attribute @content[:body] %></p>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -22,6 +22,11 @@
   </blockquote>
 <% end %>
 
+<% if @original_language.present? %>
+  <p><b><%= t(".content_original_language") %></b></p>
+  <p><%= I18n.t("locale.name", locale: @original_language) %></p>
+<% end %>
+
 <% if @content.present? %>
   <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%= @content[:id] %>)</p>
   <blockquote>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <% if @content.present? %>
-  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%= @content[:id]% >)</p>
+  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%= @content[:id] %>)</p>
   <blockquote>
     <h5><%= translated_attribute @content[:title] %></h5>
     <p><%= translated_attribute @content[:body] %></p>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -10,7 +10,7 @@
 <p><%= l @report.created_at, format: :short %></p>
 
 <p><b><%= t(".participatory_space") %></b></p>
-<p><%= translated_attribute @participatory_space.title %></p>
+<p><%= link_to translated_attribute(@participatory_space.title), resource_locator(@participatory_space).url %></p>
 
 <p><b><%= t(".reason") %></b></p>
 <p><%= t(@report.reason, organization_name: @participatory_space.organization.name, scope: "decidim.shared.flag_modal") %></p>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <% if @content.present? %>
-  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%=@content[:id]%>)</p>
+  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%= @content[:id]% >)</p>
   <blockquote>
     <h5><%= translated_attribute @content[:title] %></h5>
     <p><%= translated_attribute @content[:body] %></p>

--- a/decidim-core/app/views/decidim/reported_mailer/report.html.erb
+++ b/decidim-core/app/views/decidim/reported_mailer/report.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <% if @content.present? %>
-  <p><b><%= t(".content") %></b></p>
+  <p><b><%= t(".content") %></b> (<%= t(".id") %>: <%=@content[:id]%>)</p>
   <blockquote>
     <h5><%= translated_attribute @content[:title] %></h5>
     <p><%= translated_attribute @content[:body] %></p>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1126,9 +1126,11 @@ en:
       report:
         authors: Authors
         content: Reported content
+        content_original_language: Content original language
         date: Reported on
         details: Details
         hello: Hello %{name},
+        id: ID
         manage_moderations: Manage moderations
         participatory_space: Participatory space
         reason: Reason

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1126,6 +1126,7 @@ en:
       report:
         authors: Authors
         content: Reported content
+        content_original_language: Content original language
         date: Reported on
         details: Details
         hello: Hello %{name},

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1126,7 +1126,6 @@ en:
       report:
         authors: Authors
         content: Reported content
-        content_original_language: Content original language
         date: Reported on
         details: Details
         hello: Hello %{name},

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -54,6 +54,27 @@ module Decidim
           expect(email_body(mail)).to match(reportable.body["en"])
         end
 
+        it "does not include the content original language when there's no content" do
+          report.moderation.reportable.title = nil
+          report.moderation.reportable.body = nil
+
+          expect(email_body(mail)).not_to match("<b>Content original language</b>")
+        end
+
+        it "includes the content original language when only one language is present" do
+          report.moderation.reportable.title = { "ca" => "title", "machine_translations" => { "fi" => "title", "se" => "title" } }
+
+          expect(email_body(mail)).to match("<b>Content original language</b>")
+          expect(email_body(mail)).to match(I18n.t("locale.name", locale: "ca"))
+        end
+
+        it "includes the content original language as the organization's default when the content has more than one language" do
+          report.moderation.reportable.title = { "ca" => "title", "fi" => "title", "se" => "title" }
+
+          expect(email_body(mail)).to match("<b>Content original language</b>")
+          expect(email_body(mail)).to match(I18n.t("locale.name", locale: organization.default_locale))
+        end
+
         it "doesn't include the reported content if it's not present" do
           reportable.title = nil
           reportable.body = nil

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -56,8 +56,8 @@ module Decidim
         end
 
         it "doesn't include the reported content if it's not present" do
-          reportable.title = nil
-          reportable.body = nil
+          report.moderation.reportable.title = nil
+          report.moderation.reportable.body = nil
 
           expect(email_body(mail)).not_to match("<b>Reported content</b>")
         end

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -50,8 +50,16 @@ module Decidim
         end
 
         it "includes the reported content" do
+          expect(email_body(mail)).to match("(ID: #{reportable.id})")
           expect(email_body(mail)).to match(reportable.title["en"])
           expect(email_body(mail)).to match(reportable.body["en"])
+        end
+
+        it "doesn't include the reported content if it's not present" do
+          reportable.title = nil
+          reportable.body = nil
+
+          expect(email_body(mail)).not_to match("<b>Reported content</b>")
         end
 
         it "does not include the content original language when there's no content" do
@@ -73,13 +81,6 @@ module Decidim
 
           expect(email_body(mail)).to match("<b>Content original language</b>")
           expect(email_body(mail)).to match(I18n.t("locale.name", locale: organization.default_locale))
-        end
-
-        it "doesn't include the reported content if it's not present" do
-          reportable.title = nil
-          reportable.body = nil
-
-          expect(email_body(mail)).not_to match("<b>Content</b>")
         end
 
         context "when the author is a user" do


### PR DESCRIPTION
#### :tophat: What? Why?
Adds information to the email sent to the moderator users when a content is reported.
In detail:
 - Added the link to the participatory space;
 - Added the ID for the reported content;
 - Added the original content language (the content's language when only one available - the organization's default when multiple)

#### Testing
- Report any content (comment, proposal, etc.)
- Check the created email(s) in `tmp/letter_opener`.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![email](https://user-images.githubusercontent.com/5033945/96110663-74349b80-0ee0-11eb-8abb-63317aa66a7a.png)


:hearts: Thank you!
