### PR TITLE
Simplify Reportable concern API methods

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "manage moderations" do
   let!(:moderations) do
     reportables.first(reportables.length - 1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 1, reported_content: reportable.reported_content)
+      moderation = create(:moderation, reportable: reportable, report_count: 1, reported_content: reportable.reported_searchable_content_text)
       create(:report, moderation: moderation)
       moderation
     end
@@ -11,7 +11,7 @@ shared_examples "manage moderations" do
   let!(:moderation) { moderations.first }
   let!(:hidden_moderations) do
     reportables.last(1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_content, hidden_at: Time.current)
+      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_searchable_content_text, hidden_at: Time.current)
       create_list(:report, 3, moderation: moderation, reason: :spam)
       moderation
     end

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -130,12 +130,14 @@ module Decidim
         end
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          normalized_author.name,
-          body.values.join("\n")
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:body]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       def self.export_serializer

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -49,7 +49,7 @@ module Decidim
     end
 
     def update_reported_content!
-      @moderation.update!(reported_content: @reportable.reported_content)
+      @moderation.update!(reported_content: @reportable.reported_searchable_content_text)
     end
 
     def create_report!

--- a/decidim-core/lib/decidim/reportable.rb
+++ b/decidim-core/lib/decidim/reportable.rb
@@ -63,6 +63,7 @@ module Decidim
           reported_attributes.map do |attribute_name|
             attribute_value = attributes.with_indifferent_access[attribute_name]
             next attribute_value.values.join("\n") if attribute_value.is_a? Hash
+
             attribute_value
           end
         ).join("\n")

--- a/decidim-core/lib/decidim/reportable.rb
+++ b/decidim-core/lib/decidim/reportable.rb
@@ -43,10 +43,29 @@ module Decidim
         raise NotImplementedError
       end
 
-      # Public: The reported content in a text format so moderations can
-      #         be filtered by content.
-      def reported_content
+      # Public: The collection of attribute names that are considered
+      #         to be reportable.
+      def reported_attributes
         raise NotImplementedError
+      end
+
+      # Public: An `Array` of `String` that will be concatenated to
+      #         the reported searchable content. This content is used
+      #         in the admin dashboard to filter moderations.
+      def reported_searchable_content_extras
+        []
+      end
+
+      # Public: The reported searchable content in a text format so
+      #         moderations can be filtered by content.
+      def reported_searchable_content_text
+        reported_searchable_content_extras.concat(
+          reported_attributes.map do |attribute_name|
+            attribute_value = attributes.with_indifferent_access[attribute_name]
+            next attribute_value.values.join("\n") if attribute_value.is_a? Hash
+            attribute_value
+          end
+        ).join("\n")
       end
     end
   end

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -59,7 +59,7 @@ module Decidim
           command.call
           last_moderation = Moderation.last
 
-          expect(last_moderation.reported_content).to eq(reportable.reported_content)
+          expect(last_moderation.reported_content).to eq(reportable.reported_searchable_content_text)
         end
 
         it "sends an email to the admin" do

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -62,14 +62,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          normalized_author.name,
-          title.values.join("\n"),
-          description.values.join("\n"),
-          instructions.values.join("\n")
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:title, :description]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       # Public: Calculates whether the current debate is an AMA-styled one or not.

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component.rb
@@ -93,10 +93,12 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      def reported_content
-        [
-          normalized_author.name
-        ].join("\n")
+      def reported_attributes
+        [:title]
+      end
+
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       def allow_resource_permissions?

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -191,15 +191,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          normalized_author.name,
-          description.values.join("\n"),
-          location.values.join("\n"),
-          location_hints.values.join("\n"),
-          registration_terms.present? ? registration_terms.values.join("\n") : ""
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:description]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [normalized_author.name]
       end
 
       def online_meeting?

--- a/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
+++ b/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
@@ -59,12 +59,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          authors.map(&:name).join("\n"),
-          body
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:body]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [authors.map(&:name).join("\n")]
       end
     end
   end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -225,13 +225,14 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
-      # Public: Overrides the `reported_content` Reportable concern method.
-      def reported_content
-        [
-          authors.map(&:name).join("\n"),
-          title.values.join("\n"),
-          body.values.join("\n")
-        ].join("\n")
+      # Public: Overrides the `reported_attributes` Reportable concern method.
+      def reported_attributes
+        [:title, :body]
+      end
+
+      # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      def reported_searchable_content_extras
+        [authors.map(&:name).join("\n")]
       end
 
       # Public: Whether the proposal is official or not.


### PR DESCRIPTION
#### :tophat: What? Why?

This simplify the `Reportable` concern public API methods so each resource just needs to expose these two methods:
- `reported_attributes`: This should return an array of attribute names that can be considered as "reportables". This will be used later to check whenever a resource is considered translated to send an email to the admin when it is reported.
- `reported_searchable_content_extras` (optional): This may include an array of extra content that can be considered when filtering moderations by text. By default it only uses the content in `reported_attributes`.
 
#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.
