### PR TITLE
Moderation panel refinement

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/modules/_moderations.scss
@@ -1,21 +1,37 @@
-.moderation-details {
-  .toggle-content {
+.moderation-details{
+  .toggle-content{
     cursor: pointer;
-    margin-left: 0.5rem;
-    font-size: 0.9rem;
+    margin-left: .5rem;
+    font-size: .9rem;
   }
-  .callout {
-    &-text {
-      margin-left: 0.5rem;
-      .icon {
-        width: 0.6rem;
-        margin: 0 0.2rem;
+
+  .reported-content{
+    .original{
+      display: none
+    }
+  }
+
+  .callout{
+    &-text{
+      margin-left: .5rem;
+      .icon{
+        width: .6rem;
+        margin: 0 .2rem;
       }
     }
   }
-  dd {
+
+  dd{
     padding: $global-padding;
     background-color: $light-gray;
-    margin-bottom: 0.5rem;
+    margin-bottom: .5rem;
+  }
+
+  .reportable-authors{
+    list-style: none;
+    margin: 0;
+    .icon{
+      margin-left: .5rem;
+    }
   }
 }

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -5,10 +5,24 @@ module Decidim
     module Moderations
       # This module includes helpers to show moderation reports in admin
       module ReportsHelper
+        include Decidim::Messaging::ConversationHelper
+
         # Public: Returns the reportable's author names separated by commas.
         def reportable_author_name(reportable)
-          reportable_authors = reportable.try(:authors) || [reportable.try(:author)]
-          reportable_authors.select(&:present?).map(&:name).join(", ")
+          reportable_authors = reportable.try(:authors) || [reportable.try(:normalized_author)]
+          content_tag :ul, class: "reportable-authors" do
+            reportable_authors.select(&:present?).map do |author|
+              if author.is_a? User
+                content_tag :li do
+                  link_to current_or_new_conversation_path_with(author), target: "_blank" do
+                    "#{author.name} #{icon "envelope-closed"}".html_safe
+                  end
+                end
+              else
+                content_tag(:li, author.name)
+              end
+            end.join("").html_safe
+          end
         end
 
         # Public: Renders a small preview of the content reported.

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -14,7 +14,7 @@ module Decidim
             reportable_authors.select(&:present?).map do |author|
               if author.is_a? User
                 content_tag :li do
-                  link_to current_or_new_conversation_path_with(author), target: "_blank" do
+                  link_to current_or_new_conversation_path_with(author), target: "_blank", rel: "noopener" do
                     "#{author.name} #{icon "envelope-closed"}".html_safe
                   end
                 end
@@ -28,19 +28,6 @@ module Decidim
         # Public: Renders a small preview of the content reported.
         def reported_content_for(reportable, options = {})
           cell "decidim/reported_content", reportable, options
-        end
-
-        # Public: Renders an extract of the content reported in a text format.
-        def reported_content_excerpt_for(reportable, options = {})
-          I18n.with_locale(options.fetch(:locale, I18n.locale)) do
-            reportable_content = reportable.reported_attributes.map do |attribute_name|
-              attribute_value = reportable.attributes.with_indifferent_access[attribute_name]
-              next translated_attribute(attribute_value) if attribute_value.is_a? Hash
-
-              attribute_value
-            end
-            reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))
-          end
         end
 
         # Public: Whether the resource has some translated attribute or not.

--- a/decidim-admin/app/helpers/decidim/admin/moderations_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # This module includes helpers to show moderation in admin
+    module ModerationsHelper
+      # Public: Renders an extract of the content reported in a text format.
+      def reported_content_excerpt_for(reportable, options = {})
+        I18n.with_locale(options.fetch(:locale, I18n.locale)) do
+          reportable_content = reportable.reported_attributes.map do |attribute_name|
+            attribute_value = reportable.attributes.with_indifferent_access[attribute_name]
+            next translated_attribute(attribute_value) if attribute_value.is_a? Hash
+
+            attribute_value
+          end
+          reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -40,7 +40,7 @@
               </td>
               <td>
                 <%=
-                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url
+                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, aria: { haspopup: true }, title: reported_content_excerpt_for(moderation.reportable)
                 %>
               </td>
               <td>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -65,8 +65,8 @@
           <tr>
             <th><%= t("models.report.fields.reason", scope: "decidim.moderations") %></th>
             <th><%= t("models.report.fields.locale", scope: "decidim.moderations") %></th>
-            <th><%= t(".reported_content") %></th>
             <th><%= t("models.report.fields.details", scope: "decidim.moderations") %></th>
+            <th class="actions"><%= t("actions.title", scope: "decidim.moderations") %></th>
           </tr>
         </thead>
         <tbody>
@@ -74,14 +74,13 @@
             <tr data-id="<%= report.id %>">
               <td><%= t("decidim.admin.moderations.report.reasons.#{report.reason}") %></td>
               <td><%= report.locale.present? ? locale_name(report.locale) : "" %></td>
-              <td>
-                <%= reported_content_excerpt_for(moderation.reportable) %>
+              <td><%= report.details %></td>
+              <td class="actions">
                 <%= icon_link_to "fullscreen-enter",
                                   moderation_report_path(moderation_id: moderation, id: report.id),
                                   t("actions.expand", scope: "decidim.moderations"),
                                   class: "action-icon--expand" %>
               </td>
-              <td><%= report.details %></td>
             </tr>
           <% end %>
         </tbody>


### PR DESCRIPTION
#### :tophat: What? Why?

This refines a few things in the moderation panel:

- Removes the "Reported column" in the reports list. The content can be inspected clicking the "Expand" button.
- Changes the reportable author's list to include "Open new conversation" links.
- Adds a small preview when hovering over the "Visit URL" link in the moderations list.
 	
#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/106021/96855024-79539680-145c-11eb-9845-015d481ef1fb.png)

![image](https://user-images.githubusercontent.com/106021/96855045-81133b00-145c-11eb-98b1-b280123b9158.png)


