### PR TITLE
feat: notify author of reported content

### DIFF
--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -31,6 +31,7 @@ module Decidim
       end
 
       send_report_notification_to_moderators
+      send_report_notification_to_author
 
       if hideable?
         hide!
@@ -72,6 +73,19 @@ module Decidim
 
     def send_report_notification_to_moderators
       ReportedMailer.send_report_notification_to_users(participatory_space_moderators, @report)
+    end
+
+    def send_report_notification_to_author
+      data = {
+        event: "decidim.events.reports.report_created",
+        event_class: Decidim::ReportCreatedEvent,
+        resource: @report.moderation.reportable,
+        extra: {
+          report_reason: @report.reason
+        },
+        affected_users: @report.moderation.reportable.try(:authors) || [@report.moderation.reportable.try(:author)]
+      }
+      Decidim::EventsManager.publish(data)
     end
 
     def hideable?

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -83,7 +83,7 @@ module Decidim
         extra: {
           report_reason: @report.reason
         },
-        affected_users: @report.moderation.reportable.try(:authors) || [@report.moderation.reportable.try(:author)]
+        affected_users: @report.moderation.reportable.try(:authors) || [@report.moderation.reportable.try(:normalized_author)]
       }
       Decidim::EventsManager.publish(data)
     end

--- a/decidim-core/app/events/decidim/report_created_event.rb
+++ b/decidim-core/app/events/decidim/report_created_event.rb
@@ -16,6 +16,10 @@ module Decidim
       I18n.t("decidim.admin.moderations.report.reasons.#{extra["report_reason"]}").downcase
     end
 
+    def resource_title
+      nil
+    end
+
     def resource_type
       @resource.model_name.human.downcase
     end

--- a/decidim-core/app/events/decidim/report_created_event.rb
+++ b/decidim-core/app/events/decidim/report_created_event.rb
@@ -1,0 +1,23 @@
+# frozen-string_literal: true
+
+module Decidim
+  class ReportCreatedEvent < Decidim::Events::SimpleEvent
+    i18n_attributes :resource_path, :report_reason, :resource_type
+
+    def resource_path
+      @resource.reported_content_url
+    end
+
+    def resource_url
+      @resource.reported_content_url
+    end
+
+    def report_reason
+      I18n.t("decidim.admin.moderations.report.reasons.#{extra["report_reason"]}").downcase
+    end
+
+    def resource_type
+      @resource.model_name.human.downcase
+    end
+  end
+end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -618,6 +618,9 @@ en:
           notification_title: The %{user_group_name} user group has updated its profile, leaving it unverified. You can now verify it in the <a href="%{groups_admin_path}">admin panel</a>.
       notification_event:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
+      reports:
+        report_created:
+          notification_title: <a href="%{resource_path}">Your %{resource_type}</a> has been reported as "%{report_reason}"</a>.
       resource_endorsed:
         email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed "%{resource_title}" and we think it may be interesting to you. Check it out and contribute:'
         email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -16,6 +16,17 @@ module Decidim
           reason: "spam"
         }
       end
+      let(:author_notification) do
+        {
+          event: "decidim.events.reports.report_created",
+          event_class: Decidim::ReportCreatedEvent,
+          resource: reportable,
+          extra: {
+            report_reason: form[:reason]
+          },
+          affected_users: reportable.try(:authors) || [reportable.try(:author)]
+        }
+      end
 
       let(:command) { described_class.new(form, reportable, user) }
 
@@ -79,6 +90,11 @@ module Decidim
             .with(component.participatory_space.moderators, last_report)
         end
 
+        it "sends a notification to the reportable's author" do
+          expect(Decidim::EventsManager).to receive(:publish).with(author_notification)
+          command.call
+        end
+
         context "and the reportable has been already reported two times" do
           before do
             expect(form).to receive(:invalid?).at_least(:once).and_return(false)
@@ -106,6 +122,11 @@ module Decidim
             expect(ReportedMailer)
               .to have_received(:send_hide_notification_to_users)
               .with(component.participatory_space.moderators, last_report)
+          end
+
+          it "sends a notification to the reportable's author" do
+            expect(Decidim::EventsManager).to receive(:publish).with(author_notification)
+            command.call
           end
         end
       end

--- a/decidim-core/spec/lib/events/report_created_event_spec.rb
+++ b/decidim-core/spec/lib/events/report_created_event_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ReportCreatedEvent do
+    include_context "when a simple event"
+
+    let(:comment) { create :comment }
+    let(:moderation) { create :moderation, reportable: comment }
+    let(:report) { create :report, moderation: moderation }
+    let(:resource) { comment }
+    let(:event_name) { "decidim.events.reports.report_created" }
+    let(:extra) { { report_reason: "spam" } }
+
+    describe "notification_title" do
+      it "includes the report reason" do
+        expect(subject.notification_title).to include("spam")
+      end
+
+      it "includes the reportable link" do
+        expect(subject.notification_title).to include(comment.reported_content_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When a user reports a content with the 🏴 icon, the author(s) of the reported content will now receive a notification with a link to the content and the short reason why it has been reported. The notification, though, won't say who reported the content and the details provided by the reporter.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Login with a user (say: user@example.org | decidim123456);
Create a reportable content (e.g. a comment, proposal, etc.);
On another browser/session, login with another user (say: admin@example.org | decidim123456);
Report the content created with the previous user;
In the first browser/session, you shell receive a notification saying that you content has been reported;

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Notification](https://user-images.githubusercontent.com/5033945/96856031-cab05580-145d-11eb-8da2-15a4fa51e3f5.png)

![notification](https://user-images.githubusercontent.com/5033945/96856081-d4d25400-145d-11eb-9a4f-89ec77341a3a.gif)


:hearts: Thank you!
