### PR TITLE
Fix String to Array compairason on meetings type filter

### DIFF
--- a/decidim-budgets/spec/system/explore_budget_notifications_spec.rb
+++ b/decidim-budgets/spec/system/explore_budget_notifications_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Explore budget notifications", :slow, type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "budgets" }
+  let(:budget) { create :budget, component: component }
+  let(:projects_count) { 5 }
+  let!(:projects) do
+    create_list(:project, projects_count, budget: budget)
+  end
+  let!(:project) { projects.first }
+
+  describe "index" do
+    context "when a budgeting project was commented in a followed space" do
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+      let(:other_user) { create(:user, :confirmed, organization: component.organization) }
+
+      before do
+        switch_to_host(organization.host)
+        login_as(user, scope: :user)
+
+        # Create a notification for the follower
+        create(:follow, followable: component.participatory_space, user: user)
+        comment = create(:comment, commentable: project, author: other_user)
+        perform_enqueued_jobs do
+          Decidim::Comments::NewCommentNotificationCreator.new(comment, [], []).create
+        end
+      end
+
+      it "displays the notification for the comment" do
+        visit_notifications
+
+        within "#notifications" do
+          expect(page).to have_content(translated(project.title))
+        end
+      end
+    end
+  end
+
+  private
+
+  def visit_notifications
+    page.visit decidim.notifications_path
+  end
+end

--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -9,14 +9,6 @@ module Decidim
       include Decidim::Events::AuthorEvent
 
       included do
-        def resource_path
-          resource_locator.path(url_params)
-        end
-
-        def resource_url
-          resource_locator.url(url_params)
-        end
-
         def resource_text
           comment.formatted_body
         end
@@ -42,7 +34,7 @@ module Decidim
           @comment ||= Decidim::Comments::Comment.find(extra[:comment_id])
         end
 
-        def url_params
+        def resource_url_params
           { anchor: "comment_#{comment.id}" }
         end
       end

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -59,12 +59,24 @@ module Decidim
 
       # Caches the path for the given resource.
       def resource_path
-        @resource_path ||= resource_locator.path
+        @resource_path ||= begin
+          if resource&.respond_to?(:polymorphic_resource_path)
+            resource.polymorphic_resource_path(resource_url_params)
+          else
+            resource_locator.path(resource_url_params)
+          end
+        end
       end
 
       # Caches the URL for the given resource.
       def resource_url
-        @resource_url ||= resource_locator.url
+        @resource_url ||= begin
+          if resource&.respond_to?(:polymorphic_resource_url)
+            resource.polymorphic_resource_url(resource_url_params)
+          else
+            resource_locator.url(resource_url_params)
+          end
+        end
       end
 
       def resource_text; end
@@ -97,6 +109,10 @@ module Decidim
         return resource if resource.is_a?(Decidim::Participable)
 
         resource.try(:participatory_space)
+      end
+
+      def resource_url_params
+        {}
       end
 
       attr_reader :event_name, :resource, :user, :user_role, :extra

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -30,9 +30,9 @@ module Decidim
 
       def search_type
         case options[:type]
-        when "online"
+        when ["online"]
           query.online
-        when "in_person"
+        when ["in_person"]
           query.in_person
         else
           query

--- a/decidim-meetings/spec/services/meeting_search_spec.rb
+++ b/decidim-meetings/spec/services/meeting_search_spec.rb
@@ -74,7 +74,7 @@ module Decidim::Meetings
         end
 
         context "when online" do
-          let(:params) { default_params.merge(type: "online") }
+          let(:params) { default_params.merge(type: ["online"]) }
 
           it "only lists online meetings" do
             expect(subject).to include(online_meeting)
@@ -83,7 +83,7 @@ module Decidim::Meetings
         end
 
         context "when in_person" do
-          let(:params) { default_params.merge(type: "in_person") }
+          let(:params) { default_params.merge(type: ["in_person"]) }
 
           it "only lists online meetings" do
             expect(subject).to include(in_person_meeting)


### PR DESCRIPTION
#### :tophat: What? Why?
The Meeting type filter in the interface sends an array to the backend and in the backend is compared with a string, therefore the conditions are never met to match that filter selection

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
