### PR TITLE
Fix: missing translation for author report email

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -620,7 +620,10 @@ en:
         notification_title: An event occured to <a href="%{resource_path}">%{resource_title}</a>.
       reports:
         report_created:
-          notification_title: <a href="%{resource_path}">Your %{resource_type}</a> has been reported as "%{report_reason}"</a>.
+          email_intro: <a href="%{resource_url}">Your %{resource_type}</a> has been reported as "%{report_reason}". An administrator will review it shortly.
+          email_outro: You have received this notification because you are an author of the reported content.
+          email_subject: Your %{resource_type} has been reported
+          notification_title: <a href="%{resource_path}">Your %{resource_type}</a> has been reported as "%{report_reason}".
       resource_endorsed:
         email_intro: '%{endorser_name} %{endorser_nickname}, who you are following, has just endorsed "%{resource_title}" and we think it may be interesting to you. Check it out and contribute:'
         email_outro: You have received this notification because you are following %{endorser_nickname}. You can stop receiving notifications following the previous link.

--- a/decidim-core/spec/lib/events/report_created_event_spec.rb
+++ b/decidim-core/spec/lib/events/report_created_event_spec.rb
@@ -22,5 +22,23 @@ module Decidim
         expect(subject.notification_title).to include(comment.reported_content_url)
       end
     end
+
+    describe "email_subject" do
+      it "is generated correctly" do
+        expect(subject.email_subject).to eq("Your comment has been reported")
+      end
+    end
+
+    describe "email_outro" do
+      it "is generated correctly" do
+        expect(subject.email_outro).to eq("You have received this notification because you are an author of the reported content.")
+      end
+    end
+
+    describe "email_intro" do
+      it "is generated correctly" do
+        expect(subject.email_intro).to eq("<a href=\"#{comment.reported_content_url}\">Your comment</a> has been reported as \"spam\". An administrator will review it shortly.")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When a content is reported, an email is sent to the authors of the reported content.
The corresponding translation strings were not added.

This PR adds the translation strings and tests that the email is correctly generated.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

:hearts: Thank you!
