### PR TITLE
feat: enable meeting registrations from public area

### DIFF
--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form.js.es6
@@ -31,6 +31,7 @@
 
       const $meetingRegistrationType = $form.find("#meeting_registration_type");
       const $meetingRegistrationTerms = $form.find("#meeting_registration_terms");
+      const $meetingRegistrationEnabled = $form.find("#meeting_registration_enabled");
       const $meetingRegistrationUrl = $form.find("#meeting_registration_url");
       const $meetingAvailableSlots = $form.find("#meeting_available_slots");
 
@@ -38,11 +39,13 @@
         const $target = $(ev.target);
         toggleDependsOnSelect($target, $meetingAvailableSlots, "on_this_platform");
         toggleDependsOnSelect($target, $meetingRegistrationTerms, "on_this_platform");
+        toggleDependsOnSelect($target, $meetingRegistrationEnabled, "on_this_platform");
         toggleDependsOnSelect($target, $meetingRegistrationUrl, "on_different_platform");
       });
 
       toggleDependsOnSelect($meetingRegistrationType, $meetingAvailableSlots, "on_this_platform");
       toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationTerms, "on_this_platform");
+      toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationEnabled, "on_this_platform");
       toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationUrl, "on_different_platform");
     }
   });

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form.js.es6
@@ -31,7 +31,7 @@
 
       const $meetingRegistrationType = $form.find("#meeting_registration_type");
       const $meetingRegistrationTerms = $form.find("#meeting_registration_terms");
-      const $meetingRegistrationEnabled = $form.find("#meeting_registration_enabled");
+      const $meetingRegistrationEnabled = $form.find("#meeting_registrations_enabled");
       const $meetingRegistrationUrl = $form.find("#meeting_registration_url");
       const $meetingAvailableSlots = $form.find("#meeting_available_slots");
 

--- a/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
@@ -50,6 +50,7 @@ module Decidim
           registration_url: form.registration_url,
           available_slots: form.available_slots,
           registration_terms: { I18n.locale => form.registration_terms },
+          registrations_enabled: form.registrations_enabled,
           type_of_meeting: form.clean_type_of_meeting,
           component: form.current_component
         }

--- a/decidim-meetings/app/commands/decidim/meetings/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/update_meeting.rb
@@ -60,6 +60,7 @@ module Decidim
             registration_url: form.registration_url,
             available_slots: form.available_slots,
             registration_terms: { I18n.locale => form.registration_terms },
+            registrations_enabled: form.registrations_enabled,
             type_of_meeting: form.clean_type_of_meeting,
             online_meeting_url: form.online_meeting_url
           },

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -23,9 +23,6 @@ module Decidim
         attribute :registration_url, String
         attribute :available_slots, Integer, default: 0
 
-        TYPE_OF_MEETING = %w(in_person online).freeze
-        REGISTRATION_TYPE = %w(registration_disabled on_this_platform on_different_platform).freeze
-
         translatable_attribute :title, String
         translatable_attribute :description, String
         translatable_attribute :location, String
@@ -129,7 +126,7 @@ module Decidim
         end
 
         def type_of_meeting_select
-          TYPE_OF_MEETING.map do |type|
+          Decidim::Meetings::Meeting::TYPE_OF_MEETING.map do |type|
             [
               I18n.t("type_of_meeting.#{type}", scope: "decidim.meetings"),
               type
@@ -146,7 +143,7 @@ module Decidim
         end
 
         def registration_type_select
-          REGISTRATION_TYPE.map do |type|
+          Decidim::Meetings::Meeting::REGISTRATION_TYPE.map do |type|
             [
               I18n.t("registration_type.#{type}", scope: "decidim.meetings"),
               type

--- a/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
@@ -20,6 +20,7 @@ module Decidim
       attribute :online_meeting_url, String
       attribute :type_of_meeting, String
       attribute :registration_type, String
+      attribute :registrations_enabled, Boolean, default: false
       attribute :registration_url, String
       attribute :available_slots, Integer, default: 0
       attribute :registration_terms, String

--- a/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
@@ -54,6 +54,7 @@ module Decidim
         self.description = presenter.description(all_locales: false)
         self.location = presenter.location(all_locales: false)
         self.location_hints = presenter.location_hints(all_locales: false)
+        self.registration_terms = presenter.registration_terms(all_locales: false)
         self.type_of_meeting = if model.online_meeting?
                                  "online"
                                else

--- a/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
@@ -25,9 +25,6 @@ module Decidim
       attribute :available_slots, Integer, default: 0
       attribute :registration_terms, String
 
-      TYPE_OF_MEETING = %w(in_person online).freeze
-      REGISTRATION_TYPE = %w(registration_disabled on_this_platform on_different_platform).freeze
-
       validates :title, presence: true
       validates :description, presence: true
       validates :type_of_meeting, presence: true
@@ -115,7 +112,7 @@ module Decidim
       end
 
       def type_of_meeting_select
-        TYPE_OF_MEETING.map do |type|
+        Decidim::Meetings::Meeting::TYPE_OF_MEETING.map do |type|
           [
             I18n.t("type_of_meeting.#{type}", scope: "decidim.meetings"),
             type
@@ -132,7 +129,7 @@ module Decidim
       end
 
       def registration_type_select
-        REGISTRATION_TYPE.map do |type|
+        Decidim::Meetings::Meeting::REGISTRATION_TYPE.map do |type|
           [
             I18n.t("registration_type.#{type}", scope: "decidim.meetings"),
             type

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -48,6 +48,14 @@ module Decidim
         end
       end
 
+      def registration_terms(all_locales: false)
+        return unless meeting
+
+        handle_locales(meeting.registration_terms, all_locales) do |content|
+          content
+        end
+      end
+
       def closing_report(links: false, all_locales: false)
         return unless meeting
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
@@ -68,7 +68,7 @@
 </div>
 
 <div class="row column" id="meeting_registration_enabled">
-  <%= form.check_box :registrations_enabled  %>
+  <%= form.check_box :registrations_enabled %>
 </div>
 
 <div class="field" id="meeting_registration_url">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
@@ -67,7 +67,7 @@
   <%= text_editor_for(form, :registration_terms) %>
 </div>
 
-<div class="row column" id="meeting_registration_enabled">
+<div class="row column" id="meeting_registrations_enabled">
   <%= form.check_box :registrations_enabled %>
 </div>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
@@ -67,6 +67,10 @@
   <%= text_editor_for(form, :registration_terms) %>
 </div>
 
+<div class="row column" id="meeting_registration_enabled">
+  <%= form.check_box :registrations_enabled  %>
+</div>
+
 <div class="field" id="meeting_registration_url">
   <%= form.text_field :registration_url %>
   <p class="help-text"><%= t(".registration_url_help") %></p>

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -22,6 +22,7 @@ module Decidim::Meetings
     let(:registration_url) { "http://decidim.org" }
     let(:online_meeting_url) { "http://decidim.org" }
     let(:registration_type) { "on_this_platform" }
+    let(:registrations_enabled) { true }
     let(:available_slots) { 0 }
     let(:registration_terms) { Faker::Lorem.sentence(word_count: 3) }
     let(:form) do
@@ -46,6 +47,7 @@ module Decidim::Meetings
         available_slots: available_slots,
         registration_url: registration_url,
         registration_terms: registration_terms,
+        registrations_enabled: registrations_enabled,
         clean_type_of_meeting: type_of_meeting,
         online_meeting_url: online_meeting_url
       )
@@ -79,6 +81,11 @@ module Decidim::Meetings
       it "sets the registration_terms" do
         subject.call
         expect(translated(meeting.registration_terms)).to eq registration_terms
+      end
+
+      it "sets the registrations_enabled flag" do
+        subject.call
+        expect(meeting.registrations_enabled).to eq registrations_enabled
       end
 
       it "sets the component" do

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -142,6 +142,7 @@ module Decidim::Meetings
             available_slots: available_slots,
             registration_url: registration_url,
             registration_terms: meeting.registration_terms,
+            registrations_enabled: true,
             clean_type_of_meeting: type_of_meeting,
             online_meeting_url: online_meeting_url
           )

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -45,6 +45,7 @@ module Decidim::Meetings
         available_slots: available_slots,
         registration_url: registration_url,
         registration_terms: "The meeting registration terms",
+        registrations_enabled: true,
         clean_type_of_meeting: type_of_meeting,
         online_meeting_url: online_meeting_url
       )

--- a/decidim-meetings/spec/forms/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/meeting_form_spec.rb
@@ -58,6 +58,7 @@ module Decidim::Meetings
         registration_type: registration_type,
         available_slots: available_slots,
         registration_terms: registration_terms,
+        registrations_enabled: true,
         registration_url: registration_url
       }
     end

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -49,6 +49,8 @@ describe "User creates meeting", type: :system do
         let(:longitude) { 2.1234 }
         let!(:meeting_start_time) { Time.current + 2.days }
         let(:meeting_end_time) { meeting_start_time + 4.hours }
+        let(:meeting_available_slots) { 30 }
+        let(:meeting_registration_terms) { "These are the registration terms for this meeting" }
         let(:online_meeting_url) { "http://decidim.org" }
         let(:meeting_scope) { create :scope, organization: organization }
         let(:datetime_format) { I18n.t("time.formats.decidim_short") }
@@ -164,6 +166,46 @@ describe "User creates meeting", type: :system do
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time.strftime(time_format))
             expect(page).to have_content(meeting_end_time.strftime(time_format))
+            expect(page).not_to have_css(".button", text: "JOIN MEETING")
+            expect(page).to have_selector(".author-data", text: user_group.name)
+          end
+
+          it "creates a new meeting with registrations on this platform", :slow do
+            stub_geocoding(meeting_address, [latitude, longitude])
+
+            visit_component
+
+            click_link "New meeting"
+
+            within ".new_meeting" do
+              fill_in :meeting_title, with: meeting_title
+              fill_in :meeting_description, with: meeting_description
+              select "In person", from: :meeting_type_of_meeting
+              fill_in :meeting_location, with: meeting_location
+              fill_in :meeting_location_hints, with: meeting_location_hints
+              fill_in_geocoding :meeting_address, with: meeting_address
+              fill_in :meeting_start_time, with: meeting_start_time.strftime(datetime_format)
+              fill_in :meeting_end_time, with: meeting_end_time.strftime(datetime_format)
+              select "On this platform", from: :meeting_registration_type
+              fill_in :meeting_available_slots, with: meeting_available_slots
+              fill_in :meeting_registration_terms, with: meeting_registration_terms
+              check :meeting_registrations_enabled
+              select translated(category.name), from: :meeting_decidim_category_id
+              scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
+              select user_group.name, from: :meeting_user_group_id
+
+              find("*[type=submit]").click
+            end
+
+            expect(page).to have_content("successfully")
+            expect(page).to have_content(meeting_title)
+            expect(page).to have_content(meeting_description)
+            expect(page).to have_content(translated(category.name))
+            expect(page).to have_content(translated(meeting_scope.name))
+            expect(page).to have_content(meeting_address)
+            expect(page).to have_content(meeting_start_time.strftime(time_format))
+            expect(page).to have_content(meeting_end_time.strftime(time_format))
+            expect(page).to have_css(".button", text: "JOIN MEETING")
             expect(page).to have_selector(".author-data", text: user_group.name)
           end
         end
@@ -204,11 +246,13 @@ describe "User creates meeting", type: :system do
             expect(page).to have_field("Registration URL")
             expect(page).to have_no_field("Available slots")
             expect(page).to have_no_field("Registration terms")
+            expect(page).to have_no_field("Registrations enabled")
 
             select "On this platform", from: :meeting_registration_type
             expect(page).to have_field("Available slots")
             expect(page).to have_no_field("Registration URL")
             expect(page).to have_field("Registration terms")
+            expect(page).to have_field("Registrations enabled")
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When a meeting is created from the public area with registration type "On this platform", the creator of the meeting does not have the option to enable the registrations. This prevents the users from registering to the event.

This PR adds a "Registrations enabled" checkbox to the meeting edit form when the registration type is "On this platform".
This way, the meeting creator can decide when users can register to their meeting.

ALSO:
 - makes use of constants from the `Meeting` model instead of duplicating them (42003d7f659f9f0398765907c2f45a5c9c349d60)
 - fixes the "registration terms" field that was field that was rendered as a translation map (04198f6469b1aa2bb72598018121e0fda32f95f4)
#### :pushpin: Related Issues
- Fixes https://tremend.atlassian.net/browse/DIFE-314

#### Testing
*Describe the best way to test or validate your PR.*
 - From the public area, go to a participatory process and create a new meeting;
 - In the meeting creation form, make sure to select "On this platform" as registration type;
 - Select the "registrations enabled" checkbox and save the meeting;
 - (**test**) when redirected to the meeting page, you shall see a "Join meeting" button in the widget on the right-hand;
 - Edit the meeting and unselect the "registrations enabled" checkbox;
 - (**test**) The "Join meeting" button on right-end side widget shall now have disappeared.
#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![meeting](https://user-images.githubusercontent.com/5033945/98684993-238d5280-2367-11eb-9818-c04c063ceeaf.gif)


:hearts: Thank you!
