### PR TITLE
fix: send email to moderators

### DIFF
--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -72,7 +72,9 @@ module Decidim
     end
 
     def send_report_notification_to_moderators
-      ReportedMailer.send_report_notification_to_users(participatory_space_moderators, @report)
+      participatory_space_moderators.each do |moderator|
+        ReportedMailer.report(moderator, @report).deliver_later
+      end
     end
 
     def send_report_notification_to_author
@@ -97,7 +99,9 @@ module Decidim
     end
 
     def send_hide_notification_to_moderators
-      ReportedMailer.send_hide_notification_to_users(participatory_space_moderators, @report)
+      participatory_space_moderators.each do |moderator|
+        ReportedMailer.hide(moderator, @report).deliver_later
+      end
     end
 
     def participatory_space

--- a/decidim-core/app/jobs/decidim/machine_translation_save_job.rb
+++ b/decidim-core/app/jobs/decidim/machine_translation_save_job.rb
@@ -37,7 +37,7 @@ module Decidim
     def send_translated_report_notifications(reportable)
       reportable.moderation.reports.each do |report|
         reportable.moderation.participatory_space.moderators.each do |moderator|
-          Decidim::ReportedMailer.report(moderator, report)
+          Decidim::ReportedMailer.report(moderator, report).deliver_later
         end
       end
     end

--- a/decidim-core/app/jobs/decidim/machine_translation_save_job.rb
+++ b/decidim-core/app/jobs/decidim/machine_translation_save_job.rb
@@ -36,7 +36,9 @@ module Decidim
 
     def send_translated_report_notifications(reportable)
       reportable.moderation.reports.each do |report|
-        Decidim::ReportedMailer.send_report_notification_to_users(reportable.moderation.participatory_space.moderators, report)
+        reportable.moderation.participatory_space.moderators.each do |moderator|
+          Decidim::ReportedMailer.report(moderator, report)
+        end
       end
     end
 

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -33,18 +33,6 @@ module Decidim
       end
     end
 
-    def send_report_notification_to_users(users, report)
-      users.each do |user|
-        report(user, report).deliver_later
-      end
-    end
-
-    def send_hide_notification_to_users(users, report)
-      users.each do |user|
-        hide(user, report).deliver_later
-      end
-    end
-
     # See comment for reported_content_cell
     def current_organization
       @organization

--- a/decidim-core/spec/commands/decidim/create_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_report_spec.rb
@@ -82,12 +82,12 @@ module Decidim
         end
 
         it "sends an email to the admin" do
-          allow(ReportedMailer).to receive(:send_report_notification_to_users).and_call_original
+          allow(ReportedMailer).to receive(:report).and_call_original
           command.call
           last_report = Report.last
           expect(ReportedMailer)
-            .to have_received(:send_report_notification_to_users)
-            .with(component.participatory_space.moderators, last_report)
+            .to have_received(:report)
+            .with(admin, last_report)
         end
 
         it "sends a notification to the reportable's author" do
@@ -116,12 +116,12 @@ module Decidim
           end
 
           it "sends an email to the admin" do
-            allow(ReportedMailer).to receive(:send_hide_notification_to_users).and_call_original
+            allow(ReportedMailer).to receive(:hide).and_call_original
             command.call
             last_report = Report.last
             expect(ReportedMailer)
-              .to have_received(:send_hide_notification_to_users)
-              .with(component.participatory_space.moderators, last_report)
+              .to have_received(:hide)
+              .with(admin, last_report)
           end
 
           it "sends a notification to the reportable's author" do


### PR DESCRIPTION
#### :tophat: What? Why?
As explained in the correspondent PR in `decidim/decidim` https://github.com/decidim/decidim/pull/6726, there was a bug that prevented  emails from being sent to the moderators when a reported resource is completely translated (feature developed here: https://github.com/tremend-cofe/decidim/pull/23)

#### Testing
Unit testing

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
