### PR TITLE
feat: automatically enalble registrations when meeting on this platform

### DIFF
--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form.js.es6
@@ -31,7 +31,6 @@
 
       const $meetingRegistrationType = $form.find("#meeting_registration_type");
       const $meetingRegistrationTerms = $form.find("#meeting_registration_terms");
-      const $meetingRegistrationEnabled = $form.find("#meeting_registrations_enabled");
       const $meetingRegistrationUrl = $form.find("#meeting_registration_url");
       const $meetingAvailableSlots = $form.find("#meeting_available_slots");
 
@@ -39,13 +38,11 @@
         const $target = $(ev.target);
         toggleDependsOnSelect($target, $meetingAvailableSlots, "on_this_platform");
         toggleDependsOnSelect($target, $meetingRegistrationTerms, "on_this_platform");
-        toggleDependsOnSelect($target, $meetingRegistrationEnabled, "on_this_platform");
         toggleDependsOnSelect($target, $meetingRegistrationUrl, "on_different_platform");
       });
 
       toggleDependsOnSelect($meetingRegistrationType, $meetingAvailableSlots, "on_this_platform");
       toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationTerms, "on_this_platform");
-      toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationEnabled, "on_this_platform");
       toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationUrl, "on_different_platform");
     }
   });

--- a/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
@@ -137,6 +137,10 @@ module Decidim
           ]
         end
       end
+
+      def registrations_enabled
+        on_this_platform?
+      end
     end
   end
 end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
@@ -67,10 +67,6 @@
   <%= text_editor_for(form, :registration_terms) %>
 </div>
 
-<div class="row column" id="meeting_registrations_enabled">
-  <%= form.check_box :registrations_enabled %>
-</div>
-
 <div class="field" id="meeting_registration_url">
   <%= form.text_field :registration_url %>
   <p class="help-text"><%= t(".registration_url_help") %></p>

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -189,7 +189,6 @@ describe "User creates meeting", type: :system do
               select "On this platform", from: :meeting_registration_type
               fill_in :meeting_available_slots, with: meeting_available_slots
               fill_in :meeting_registration_terms, with: meeting_registration_terms
-              check :meeting_registrations_enabled
               select translated(category.name), from: :meeting_decidim_category_id
               scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
               select user_group.name, from: :meeting_user_group_id
@@ -246,13 +245,11 @@ describe "User creates meeting", type: :system do
             expect(page).to have_field("Registration URL")
             expect(page).to have_no_field("Available slots")
             expect(page).to have_no_field("Registration terms")
-            expect(page).to have_no_field("Registrations enabled")
 
             select "On this platform", from: :meeting_registration_type
             expect(page).to have_field("Available slots")
             expect(page).to have_no_field("Registration URL")
             expect(page).to have_field("Registration terms")
-            expect(page).to have_field("Registrations enabled")
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When a user creates a meeting from the public area, the registrations shall be automatically enabled, without asking the user to check the correspondent checkbox.

The `registrations_enabled` flag is used to enable/disable the Decidim registration system, so it only has to be set to true when the meeting is "On this platform".

For the other cases  - "Registrations disabled" and "On a different platform" - the flag shall be set to false. No button will be rendered for the former, a "Join meeting" button redirecting to the external system for the latter.

This PR undoes some of the changes introduced in https://github.com/tremend-cofe/decidim/pull/47 to automatically manage the `registrations_enabled` flag.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/tremend-cofe/decidim/pull/47
- Fixes https://tremend.atlassian.net/browse/DIFE-314?focusedCommentId=147536

#### Testing
- from the public area, navigate to a participatory process and create a new meeting.
- change the meeting's "Registration type". After saving and being redirected to the meeting detail page, you shall expect:
  - Registration type = "Registration disabled" -> No join button;
  - Registration type = "On this platform" -> "Join meeting" button with number of available slots;
  - Registration type = "On a different platform" -> "Join meeting" button redirecting to the external URL specified when creating the meeting.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
