### PR TITLE
NameError -  uninitialized constant Decidim::Elections

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/vcr.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/vcr.rb
@@ -8,6 +8,10 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.ignore_request do |request|
-    URI(request.uri).port != URI(Decidim::Elections.bulletin_board.server).port
+    if defined?(Decidim::Elections)
+      URI(request.uri).port != URI(Decidim::Elections.bulletin_board.server).port
+    else 
+      true
+    end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/vcr.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/vcr.rb
@@ -10,7 +10,7 @@ VCR.configure do |config|
   config.ignore_request do |request|
     if defined?(Decidim::Elections)
       URI(request.uri).port != URI(Decidim::Elections.bulletin_board.server).port
-    else 
+    else
       true
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Our installation does not use the elections module, however is using the decidim testing framework. The change made the test failing with           
          NameError:
            uninitialized constant Decidim::Elections


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

### StackTrace

          # /bundle_cache/ruby/2.7.0/gems/bootsnap-1.4.7/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `block in load_missing_constant'
          # /bundle_cache/ruby/2.7.0/gems/bootsnap-1.4.7/lib/bootsnap/load_path_cache/core_ext/active_support.rb:9:in `without_bootsnap_cache'
          # /bundle_cache/ruby/2.7.0/gems/bootsnap-1.4.7/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `rescue in load_missing_constant'
          # /bundle_cache/ruby/2.7.0/gems/bootsnap-1.4.7/lib/bootsnap/load_path_cache/core_ext/active_support.rb:59:in `load_missing_constant'
          # /bundle_cache/ruby/2.7.0/bundler/gems/decidim-b617a0a2f35b/decidim-dev/lib/decidim/dev/test/rspec_support/vcr.rb:11:in `block (2 levels) in <main>'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/util/variable_args_block_caller.rb:9:in `call_block'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/util/hooks.rb:15:in `conditionally_invoke'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/util/hooks.rb:30:in `block in invoke_hook'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/util/hooks.rb:29:in `map'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/util/hooks.rb:29:in `invoke_hook'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/request_ignorer.rb:37:in `ignore?'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/request_handler.rb:59:in `should_ignore?'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/request_handler.rb:36:in `request_type'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/request_handler.rb:10:in `handle'
          # /bundle_cache/ruby/2.7.0/gems/vcr-6.0.0/lib/vcr/library_hooks/webmock.rb:144:in `block in <module:WebMock>'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:33:in `block (2 levels) in register_global_stub'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:39:in `synchronize'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:39:in `block in register_global_stub'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/request_pattern.rb:40:in `matches?'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:73:in `block in request_stub_for'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:72:in `each'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:72:in `detect'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:72:in `request_stub_for'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/stub_registry.rb:64:in `response_for_request'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/http_lib_adapters/net_http.rb:79:in `request'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/server.rb:56:in `block in responsive?'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/http_lib_adapters/net_http.rb:123:in `start_without_connect'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/server/checker.rb:36:in `make_request'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/server/checker.rb:28:in `http_request'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/server/checker.rb:14:in `request'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/server.rb:56:in `responsive?'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/server.rb:73:in `boot'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/session.rb:93:in `initialize'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara.rb:424:in `new'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara.rb:424:in `block in session_pool'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara.rb:315:in `current_session'
          # /bundle_cache/ruby/2.7.0/gems/capybara-3.33.0/lib/capybara/dsl.rb:46:in `page'
          # /bundle_cache/ruby/2.7.0/gems/system_test_html_screenshots-0.1.2/lib/system_test_html_screenshots.rb:10:in `take_screenshot'
          # /bundle_cache/ruby/2.7.0/gems/webmock-3.10.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'
          # ------------------
          # --- Caused by: ---
          # NameError:
          #   uninitialized constant Decidim::Elections
          #   /bundle_cache/ruby/2.7.0/gems/bootsnap-1.4.7/lib/bootsnap/load_path_cache/core_ext/active_support.rb:61:in `block in load_missing_constant'



:hearts: Thank you!
