### PR TITLE
fix: hide meeting stats when not available

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -230,6 +230,14 @@ module Decidim
         registration_type == "on_different_platform"
       end
 
+      def has_contributions?
+        contributions_count && contributions_count.positive?
+      end
+
+      def has_attendees?
+        attendees_count && attendees_count.positive?
+      end
+
       private
 
       def can_participate_in_meeting?(user)

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -58,13 +58,13 @@ edit_link(
         <% double = meeting.has_contributions? && meeting.has_attendees? %>
         <div class="card card--secondary extra definition-data">
           <% if meeting.has_contributions? %>
-            <div class=<%="definition-data__item #{"definition-data__item--double" if double}"%>>
+            <div class="definition-data__item <%= "definition-data__item--double" if double %>">
               <span class="definition-data__title"><%= t(".contributions") %></span>
               <span class="definition-data__number"><%= meeting.contributions_count %></span>
             </div>
           <% end %>
           <% if meeting.has_attendees? %>
-            <div class=<%="definition-data__item #{"definition-data__item--double" if double}"%>>
+            <div class="definition-data__item <%= "definition-data__item--double" if double %>">
               <span class="definition-data__title"><%= t(".attendees") %></span>
               <span class="definition-data__number"><%= meeting.attendees_count %></span>
             </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -55,26 +55,26 @@ edit_link(
         <%= render partial: "decidim/shared/follow_button", locals: { followable: meeting, large: false  } %>
       </div>
       <% if meeting.closed? %>
+        <% double = meeting.has_contributions? && meeting.has_attendees? %>
         <div class="card card--secondary extra definition-data">
-          <% if meeting.contributions_count && meeting.contributions_count.positive? %>
-            <div class="definition-data__item definition-data__item--double">
-              <span class="definition-data__title"><%= t(".attendees") %></span>
-              <span class="definition-data__number"><%= meeting.attendees_count %></span>
-            </div>
-            <div class="definition-data__item definition-data__item--double">
+          <% if meeting.has_contributions? %>
+            <div class=<%="definition-data__item #{"definition-data__item--double" if double}"%>>
               <span class="definition-data__title"><%= t(".contributions") %></span>
               <span class="definition-data__number"><%= meeting.contributions_count %></span>
             </div>
-          <% else %>
-            <div class="definition-data__item">
+          <% end %>
+          <% if meeting.has_attendees? %>
+            <div class=<%="definition-data__item #{"definition-data__item--double" if double}"%>>
               <span class="definition-data__title"><%= t(".attendees") %></span>
               <span class="definition-data__number"><%= meeting.attendees_count %></span>
             </div>
           <% end %>
-          <div class="definition-data__item">
-            <span class="definition-data__title"><%= t(".organizations") %></span>
-            <span class="definition-data__text"><%= simple_format(meeting.attending_organizations) %></span>
-          </div>
+          <% if meeting.attending_organizations %>
+            <div class="definition-data__item">
+              <span class="definition-data__title"><%= t(".organizations") %></span>
+              <span class="definition-data__text"><%= simple_format(meeting.attending_organizations) %></span>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/decidim-meetings/spec/system/user_close_meeting.rb
+++ b/decidim-meetings/spec/system/user_close_meeting.rb
@@ -52,6 +52,8 @@ describe "User edit meeting", type: :system do
 
       expect(page).to have_content(closing_report)
       expect(page).not_to have_content "Close meeting"
+      expect(page).not_to have_content "ATTENDEES COUNT"
+      expect(page).not_to have_content "ATTENDING ORGANIZATIONS"
       expect(meeting.reload.closed_at).not_to be nil
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Conditionally shows/hides the meeting stats when the meeting is closed.

#### :pushpin: Related Issues
- Fixes https://tremend.atlassian.net/browse/DIFE-366

#### Testing
To test that the original issue is solved (https://tremend.atlassian.net/browse/DIFE-366):
- As a user, create a meeting from the common area;
- Close the meeting;
- _(test)_ Make sure that the card on the righthand side doesn't show "ATTENDEES COUNT" nor "ATTENDING ORGANIZATIONS"

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Closed meeting with attendee count, contribution count and attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 35 57" src="https://user-images.githubusercontent.com/5033945/100886613-5208d400-34b4-11eb-868d-c16809eefd1f.png">

Closed meeting with contribution count and attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 45 08" src="https://user-images.githubusercontent.com/5033945/100886616-533a0100-34b4-11eb-8d5b-d43b26386259.png">

Closed meeting with attendee count and attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 46 05" src="https://user-images.githubusercontent.com/5033945/100886618-53d29780-34b4-11eb-8a8d-44873bfb9453.png">

Closed meeting with only attending organizations
<img width="285" alt="Screenshot 2020-12-02 at 14 46 30" src="https://user-images.githubusercontent.com/5033945/100886622-546b2e00-34b4-11eb-9462-b92143180e1b.png">

Closed meeting with no stats (as when closed from the public area)
<img width="285" alt="Screenshot 2020-12-02 at 14 51 01" src="https://user-images.githubusercontent.com/5033945/100886624-5503c480-34b4-11eb-9ffe-83297c5f6f61.png">


:hearts: Thank you!
