### PR TITLE
[DIFE-334] Add a general moderation panel

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Admin
+    module GlobalModerationContext
+      extend ActiveSupport::Concern
+
+      included do
+        # Private: Overwrites the method from the parent controller so that the
+        # permission system does not overwrite permissions.
+        def permission_resource
+          :global_moderation
+        end
+
+        # Private: Finds the participatory spaces the current user is admin to.
+        # This is only used for users that are "participatoy space admins", not
+        # organization-wide admins. This method will later be used to find out
+        # what moderations can the current user manage.
+        #
+        # Returns an Array.
+        def spaces_user_is_admin_to
+          @spaces_user_is_admin_to ||=
+            Decidim.participatory_space_manifests.flat_map do |manifest|
+              Decidim
+                .find_participatory_space_manifest(manifest.name)
+                .participatory_spaces
+                .call(current_organization)&.select do |space|
+                  space.moderators.exists?(id: current_user.id)
+                end
+            end
+        end
+
+        # Private: finds the moderations the current user can manage, taking into
+        # account whether the user is an organization-wide admin or a
+        # "participatory space admin".
+        #
+        # Returns an `ActiveRecord::Relation`
+        def moderations_for_user
+          @moderations_for_user ||=
+            if current_user.admin?
+              Decidim::Moderation.all
+            else
+              Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
+            end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
@@ -7,44 +7,10 @@ module Decidim
       class ReportsController < Decidim::Admin::Moderations::ReportsController
         layout "decidim/admin/global_moderations"
 
-        def permission_resource
-          :global_moderation
-        end
+        include Decidim::Admin::GlobalModerationContext
 
         def moderation
           @moderation ||= moderations_for_user.find(params[:moderation_id])
-        end
-
-        # Private: Finds the participatory spaces the current user is admin to.
-        # This is only used for users that are "participatoy space admins", not
-        # organization-wide admins. This method will later be used to find out
-        # what moderations can the current user manage.
-        #
-        # Returns an Array.
-        def spaces_user_is_admin_to
-          @spaces_user_is_admin_to ||=
-            Decidim.participatory_space_manifests.flat_map do |manifest|
-              Decidim
-                .find_participatory_space_manifest(manifest.name)
-                .participatory_spaces
-                .call(current_organization)&.select do |space|
-                  space.moderators.exists?(id: current_user.id)
-                end
-            end
-        end
-
-        # Private: finds the mdoeration the current user can manage, taking into
-        # account whether the user is an organization-wide admin or a
-        # "participatory space admin".
-        #
-        # Returns an `ActiveRecord::Relation`
-        def moderations_for_user
-          @moderations_for_user ||=
-            if current_user.admin?
-              Decidim::Moderation.all
-            else
-              Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
-            end
         end
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
@@ -27,8 +27,8 @@ module Decidim
               Decidim
                 .find_participatory_space_manifest(manifest.name)
                 .participatory_spaces
-                .call(organization)&.select do |space|
-                  space.admins.exists?(id: user.id)
+                .call(current_organization)&.select do |space|
+                  space.moderators.exists?(id: current_user.id)
                 end
             end
         end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module GlobalModerations
+      # This controller allows admins to manage reports in a moderation.
+      class ReportsController < Decidim::Admin::Moderations::ReportsController
+        def permission_resource
+          :global_moderation
+        end
+
+        def moderation
+          @moderation ||= moderations_for_user.find(params[:moderation_id])
+        end
+
+        # Private: Finds the participatory spaces the current user is admin to.
+        # This is only used for users that are "participatoy space admins", not
+        # organization-wide admins. This method will later be used to find out
+        # what moderations can the current user manage.
+        #
+        # Returns an Array.
+        def spaces_user_is_admin_to
+          @spaces_user_is_admin_to ||=
+            Decidim.participatory_space_manifests.flat_map do |manifest|
+              Decidim
+                .find_participatory_space_manifest(manifest.name)
+                .participatory_spaces
+                .call(organization)&.select do |space|
+                  space.admins.exists?(id: user.id)
+                end
+            end
+        end
+
+        # Private: finds the mdoeration the current user can manage, taking into
+        # account whether the user is an organization-wide admin or a
+        # "participatory space admin".
+        #
+        # Returns an `ActiveRecord::Relation`
+        def moderations_for_user
+          @moderations_for_user ||=
+            if current_user.admin?
+              Decidim::Moderation.all
+            else
+              Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
+            end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations/reports_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     module GlobalModerations
       # This controller allows admins to manage reports in a moderation.
       class ReportsController < Decidim::Admin::Moderations::ReportsController
+        layout "decidim/admin/global_moderations"
+
         def permission_resource
           :global_moderation
         end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
@@ -7,6 +7,8 @@ module Decidim
     class GlobalModerationsController < Decidim::Admin::ModerationsController
       layout "decidim/admin/global_moderations"
 
+      include Decidim::Admin::GlobalModerationContext
+
       # Private: This method is used by the `Filterable` concern as the base query
       # without applying filtering and/or sorting options.
       def collection
@@ -18,50 +20,12 @@ module Decidim
           end
       end
 
-      # Private: Finds the participatory spaces the current user is admin to.
-      # This is only used for users that are "participatoy space admins", not
-      # organization-wide admins. This method will later be used to find out
-      # what moderations can the current user manage.
-      #
-      # Returns an Array.
-      def spaces_user_is_admin_to
-        @spaces_user_is_admin_to ||=
-          Decidim.participatory_space_manifests.flat_map do |manifest|
-            Decidim
-              .find_participatory_space_manifest(manifest.name)
-              .participatory_spaces
-              .call(current_organization)&.select do |space|
-                space.moderators.exists?(id: current_user.id)
-              end
-          end
-      end
-
-      # Private: finds the moderations the current user can manage, taking into
-      # account whether the user is an organization-wide admin or a
-      # "participatory space admin".
-      #
-      # Returns an `ActiveRecord::Relation`
-      def moderations_for_user
-        @moderations_for_user ||=
-          if current_user.admin?
-            Decidim::Moderation.all
-          else
-            Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
-          end
-      end
-
       # Private: fins the reportable of the specific moderation the user is
       # trying to manage.
       #
       # Returns a resource implementing the `Decidim::Reportable` concern.
       def reportable
         @reportable ||= moderations_for_user.find(params[:id]).reportable
-      end
-
-      # Private: Overwrites the method from the parent controller so that the
-      # permission system does not overwrite permissions.
-      def permission_resource
-        :global_moderation
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
@@ -36,7 +36,7 @@ module Decidim
           end
       end
 
-      # Private: finds the mdoeration the current user can manage, taking into
+      # Private: finds the moderations the current user can manage, taking into
       # account whether the user is an organization-wide admin or a
       # "participatory space admin".
       #
@@ -48,6 +48,14 @@ module Decidim
           else
             Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
           end
+      end
+
+      # Private: fins the reportable of the specific moderation the user is
+      # trying to manage.
+      #
+      # Returns a resource implementing the `Decidim::Reportable` concern.
+      def reportable
+        @reportable ||= moderations_for_user.find(params[:id]).reportable
       end
 
       # Private: Overwrites the method from the parent controller so that the

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
@@ -30,8 +30,8 @@ module Decidim
             Decidim
               .find_participatory_space_manifest(manifest.name)
               .participatory_spaces
-              .call(organization)&.select do |space|
-                space.admins.exists?(id: user.id)
+              .call(current_organization)&.select do |space|
+                space.moderators.exists?(id: current_user.id)
               end
           end
       end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # This controller allows admin users to manage all moderations from the
+    # participatory spaces they have access to.
+    class GlobalModerationsController < Decidim::Admin::ModerationsController
+      # Private: This method is used by the `Filterable` concern as the base query
+      # without applying filtering and/or sorting options.
+      def collection
+        @collection ||=
+          if params[:hidden]
+            moderations_for_user.where.not(hidden_at: nil)
+          else
+            moderations_for_user.where(hidden_at: nil)
+          end
+      end
+
+      # Private: Finds the participatory spaces the current user is admin to.
+      # This is only used for users that are "participatoy space admins", not
+      # organization-wide admins. This method will later be used to find out
+      # what moderations can the current user manage.
+      #
+      # Returns an Array.
+      def spaces_user_is_admin_to
+        @spaces_user_is_admin_to ||=
+          Decidim.participatory_space_manifests.flat_map do |manifest|
+            Decidim
+              .find_participatory_space_manifest(manifest.name)
+              .participatory_spaces
+              .call(organization)&.select do |space|
+                space.admins.exists?(id: user.id)
+              end
+          end
+      end
+
+      # Private: finds the mdoeration the current user can manage, taking into
+      # account whether the user is an organization-wide admin or a
+      # "participatory space admin".
+      #
+      # Returns an `ActiveRecord::Relation`
+      def moderations_for_user
+        @moderations_for_user ||=
+          if current_user.admin?
+            Decidim::Moderation.all
+          else
+            Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
+          end
+      end
+
+      # Private: Overwrites the method from the parent controller so that the
+      # permission system does not overwrite permissions.
+      def permission_resource
+        :global_moderation
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/global_moderations_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     # This controller allows admin users to manage all moderations from the
     # participatory spaces they have access to.
     class GlobalModerationsController < Decidim::Admin::ModerationsController
+      layout "decidim/admin/global_moderations"
+
       # Private: This method is used by the `Filterable` concern as the base query
       # without applying filtering and/or sorting options.
       def collection

--- a/decidim-admin/app/controllers/decidim/admin/moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations/reports_controller.rb
@@ -5,14 +5,14 @@ module Decidim
     module Moderations
       # This controller allows admins to manage reports in a moderation.
       class ReportsController < Decidim::Admin::ApplicationController
-        helper_method :moderation, :reports
+        helper_method :moderation, :reports, :permission_resource
 
         def index
-          enforce_permission_to :read, :moderation
+          enforce_permission_to :read, permission_resource
         end
 
         def show
-          enforce_permission_to :read, :moderation
+          enforce_permission_to :read, permission_resource
           @report = reports.find(params[:id])
         end
 
@@ -28,6 +28,10 @@ module Decidim
 
         def participatory_space_moderations
           @participatory_space_moderations ||= Decidim::Moderation.where(participatory_space: current_participatory_space)
+        end
+
+        def permission_resource
+          :moderation
         end
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -6,7 +6,7 @@ module Decidim
     class ModerationsController < Decidim::Admin::ApplicationController
       include Decidim::Moderations::Admin::Filterable
 
-      helper_method :moderations, :allowed_to?, :query
+      helper_method :moderations, :allowed_to?, :query, :permission_resource
 
       def index
         enforce_permission_to :read, permission_resource

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -9,16 +9,16 @@ module Decidim
       helper_method :moderations, :allowed_to?, :query
 
       def index
-        enforce_permission_to :read, :moderation
+        enforce_permission_to :read, permission_resource
       end
 
       def show
-        enforce_permission_to :read, :moderation
+        enforce_permission_to :read, permission_resource
         @moderation = collection.find(params[:id])
       end
 
       def unreport
-        enforce_permission_to :unreport, :moderation
+        enforce_permission_to :unreport, permission_resource
 
         Admin::UnreportResource.call(reportable, current_user) do
           on(:ok) do
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def hide
-        enforce_permission_to :hide, :moderation
+        enforce_permission_to :hide, permission_resource
 
         Admin::HideResource.call(reportable, current_user) do
           on(:ok) do
@@ -50,7 +50,7 @@ module Decidim
       end
 
       def unhide
-        enforce_permission_to :unhide, :moderation
+        enforce_permission_to :unhide, permission_resource
 
         Admin::UnhideResource.call(reportable, current_user) do
           on(:ok) do
@@ -92,6 +92,14 @@ module Decidim
 
       def participatory_space_moderations
         @participatory_space_moderations ||= Decidim::Moderation.where(participatory_space: current_participatory_space)
+      end
+
+      # Private: Defines the resource that permissions will check. This is
+      # added so that the `GlobalModerationController` can overwrite this method
+      # and define the custom permission resource, so that the permission system
+      # is not overridden.
+      def permission_resource
+        :moderation
       end
     end
   end

--- a/decidim-admin/app/helpers/decidim/admin/moderations_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations_helper.rb
@@ -16,6 +16,21 @@ module Decidim
           reportable_content.filter(&:present?).join(". ").truncate(options.fetch(:limit, 100))
         end
       end
+
+      # Public: Finds the type and name of the participatory space the given
+      # `reportable` object is associated to.
+      #
+      # Returns a String, or `nil` if the space is not found.
+      def participatory_space_title_for(reportable, options = {})
+        space = reportable.try(:participatory_space)
+        return unless space
+
+        I18n.with_locale(options.fetch(:locale, I18n.locale)) do
+          title = translated_attribute(space.try(:title) || space.try(:name))
+          type = space.class.model_name.human
+          [type, title].compact.join(": ").truncate(options.fetch(:limit, 100))
+        end
+      end
     end
   end
 end

--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -29,6 +29,8 @@ module Decidim
         read_admin_dashboard_action?
         apply_newsletter_permissions_for_admin!
 
+        allow! if permission_action.subject == :global_moderation
+
         if user.admin? && admin_terms_accepted?
           allow! if read_admin_log_action?
           allow! if read_metrics_action?

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -68,21 +68,21 @@
                                   moderation_reports_path(moderation_id: moderation),
                                   t("actions.expand", scope: "decidim.moderations"),
                                   class: "action-icon--expand" %>
-                <% if !moderation.reportable.hidden? && allowed_to?(:unreport, :moderation) %>
+                <% if !moderation.reportable.hidden? && allowed_to?(:unreport, permission_resource) %>
                   <%= icon_link_to "action-undo",
                                    unreport_moderation_path(id: moderation),
                                    t("actions.unreport", scope: "decidim.moderations"),
                                    class: "action-icon--unreport",
                                    method: :put %>
                 <% end %>
-                <% if !moderation.reportable.hidden? && allowed_to?(:hide, :moderation) %>
+                <% if !moderation.reportable.hidden? && allowed_to?(:hide, permission_resource) %>
                   <%= icon_link_to "eye",
                                    hide_moderation_path(id: moderation),
                                    t("actions.hide", scope: "decidim.moderations"),
                                    class: "action-icon--hide",
                                    method: :put %>
                 <% end %>
-                <% if moderation.reportable.hidden? && allowed_to?(:unhide, :moderation) %>
+                <% if moderation.reportable.hidden? && allowed_to?(:unhide, permission_resource) %>
                   <%= icon_link_to "eye",
                                    unhide_moderation_path(id: moderation),
                                    t("actions.unhide", scope: "decidim.moderations"),

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -18,6 +18,9 @@
           <tr>
             <th><%= t("models.moderation.fields.reportable_id", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reportable_type", scope: "decidim.moderations") %></th>
+            <% if !respond_to?(:current_participatory_space) %>
+              <th><%= t("models.moderation.fields.participatory_space", scope: "decidim.moderations") %></th>
+            <% end %>
             <th><%= sort_link(query, :report_count, t("models.moderation.fields.report_count", scope: "decidim.moderations")) %></th>
             <th><%= t("models.moderation.fields.reported_content_url", scope: "decidim.moderations") %></th>
             <th><%= t("models.moderation.fields.reports", scope: "decidim.moderations") %></th>
@@ -35,6 +38,11 @@
               <td>
                 <%= moderation.reportable.class.name.demodulize %>
               </td>
+              <% if !respond_to?(:current_participatory_space) %>
+                <td>
+                  <%= participatory_space_title_for(moderation.reportable) %>
+                </td>
+              <% end %>
               <td>
                 <%= moderation.report_count %>
               </td>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -90,13 +90,13 @@
 </div>
 
 <div class="button--double form-general-submit">
-  <% if !moderation.reportable.hidden? && allowed_to?(:unreport, :moderation) %>
+  <% if !moderation.reportable.hidden? && allowed_to?(:unreport, permission_resource) %>
     <%= link_to t("actions.unreport", scope: "decidim.moderations"), unreport_moderation_path(id: moderation), method: :put, class: "button" %>
   <% end %>
-  <% if !moderation.reportable.hidden? && allowed_to?(:hide, :moderation) %>
+  <% if !moderation.reportable.hidden? && allowed_to?(:hide, permission_resource) %>
     <%= link_to t("actions.hide", scope: "decidim.moderations"), hide_moderation_path(id: moderation), method: :put, class: "button alert" %>
   <% end %>
-  <% if moderation.reportable.hidden? && allowed_to?(:unhide, :moderation) %>
+  <% if moderation.reportable.hidden? && allowed_to?(:unhide, permission_resource) %>
     <%= link_to t("actions.unhide", scope: "decidim.moderations"), unhide_moderation_path(id: moderation), method: :put, class: "button alert" %>
   <% end %>
 </div>

--- a/decidim-admin/app/views/layouts/decidim/admin/global_moderations.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/global_moderations.html.erb
@@ -1,0 +1,19 @@
+<% content_for :secondary_nav do %>
+  <div class="secondary-nav">
+    <div class="secondary-nav__title">
+      <%= t ".title" %>
+    </div>
+    <ul>
+      <li <% if params[:hidden].blank? %> class="is-active" <% end %>>
+        <%= link_to t("actions.not_hidden", scope: "decidim.moderations"), decidim_admin.moderations_path %>
+      </li>
+      <li <% if params[:hidden].present? %> class="is-active" <% end %>>
+        <%= link_to t("actions.hidden", scope: "decidim.moderations"), decidim_admin.moderations_path(hidden: true) %>
+      </li>
+    </ul>
+  </div>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <%= yield %>
+<% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -384,7 +384,7 @@ en:
         help_sections: Help sections
         homepage: Homepage
         impersonations: Impersonations
-        moderation: Moderations
+        moderation: Global moderations
         newsletters: Newsletters
         participants: Participants
         reported_users: Reported Users

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -384,6 +384,7 @@ en:
         help_sections: Help sections
         homepage: Homepage
         impersonations: Impersonations
+        moderation: Moderations
         newsletters: Newsletters
         participants: Participants
         reported_users: Reported Users
@@ -887,6 +888,7 @@ en:
           fields:
             created_at: Creation date
             hidden_at: Hidden at
+            participatory_space: Participatory space
             report_count: Count
             reportable_id: Id
             reportable_type: Type

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -906,6 +906,8 @@ en:
   layouts:
     decidim:
       admin:
+        global_moderations:
+          title: Global moderations
         newsletters:
           title: Newsletters
         settings:

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -111,7 +111,7 @@ Decidim::Admin::Engine.routes.draw do
         put :hide
         put :unhide
       end
-      resources :reports, controller: "moderations/reports", only: [:index, :show]
+      resources :reports, controller: "global_moderations/reports", only: [:index, :show]
     end
 
     root to: "dashboard#show"

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -105,6 +105,15 @@ Decidim::Admin::Engine.routes.draw do
 
     resources :share_tokens, only: :destroy
 
+    resources :moderations, controller: "global_moderations" do
+      member do
+        put :unreport
+        put :hide
+        put :unhide
+      end
+      resources :reports, controller: "moderations/reports", only: [:index, :show]
+    end
+
     root to: "dashboard#show"
   end
 end

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -46,6 +46,7 @@ module Decidim
                     position: 4,
                     active: [%w(
                       decidim/admin/global_moderations
+                      decidim/admin/global_moderations/reports
                     ), []],
                     if: allowed_to?(:read, :global_moderation)
 

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -40,10 +40,19 @@ module Decidim
                     position: 1,
                     active: ["decidim/admin/dashboard" => :show]
 
+          menu.item I18n.t("menu.moderation", scope: "decidim.admin"),
+                    decidim_admin.moderations_path,
+                    icon_name: "flag",
+                    position: 4,
+                    active: [%w(
+                      decidim/admin/global_moderations
+                    ), []],
+                    if: allowed_to?(:read, :global_moderation)
+
           menu.item I18n.t("menu.static_pages", scope: "decidim.admin"),
                     decidim_admin.static_pages_path,
                     icon_name: "book",
-                    position: 4,
+                    position: 4.5,
                     active: [%w(
                       decidim/admin/static_pages
                       decidim/admin/static_page_topics

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -16,10 +16,11 @@ shared_examples "manage moderations" do
       moderation
     end
   end
+  let(:moderations_link_text) { "Moderations" }
 
   before do
     visit participatory_space_path
-    click_link "Moderations"
+    click_link moderations_link_text
   end
 
   context "when listing moderations" do
@@ -94,7 +95,9 @@ shared_examples "manage moderations" do
 
   context "when listing hidden resources" do
     it "user can review them" do
-      click_link "Hidden"
+      within ".card-title" do
+        click_link "Hidden"
+      end
 
       hidden_moderations.each do |moderation|
         within "tr[data-id=\"#{moderation.id}\"]" do

--- a/decidim-admin/spec/helpers/menu_helper_spec.rb
+++ b/decidim-admin/spec/helpers/menu_helper_spec.rb
@@ -17,13 +17,14 @@ module Decidim
 
         it "renders the default main menu" do
           expect(default_main_menu).to \
-            have_selector("li", count: 12) &
+            have_selector("li", count: 13) &
             have_link("Dashboard", href: "/admin/") &
             have_link("Processes", href: "/admin/participatory_processes") &
             have_link("Conferences", href: "/admin/conferences") &
             have_link("Assemblies", href: "/admin/assemblies") &
             have_link("Consultations", href: "/admin/consultations") &
             have_link("Initiatives", href: "/admin/initiatives") &
+            have_link("Global moderation", href: "/admin/moderations") &
             have_link("Pages", href: "/admin/static_pages") &
             have_link("Participants", href: "/admin/users") &
             have_link("Newsletters", href: "/admin/newsletters") &

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages global moderations", type: :system do
+  let!(:user) do
+    create(
+      :user,
+      :confirmed,
+      :admin,
+      organization: organization
+    )
+  end
+  let(:organization) { current_component.organization }
+  let(:current_component) { create :component }
+  let!(:reportables) { create_list(:dummy_resource, 2, component: current_component) }
+  let(:participatory_space_path) do
+    decidim_admin.moderations_path
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  it_behaves_like "manage moderations" do
+    let(:moderations_link_text) { "Global moderations" }
+  end
+end

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Space admin manages global moderations", type: :system do
+  let!(:user) do
+    create(
+      :process_admin,
+      :confirmed,
+      organization: organization,
+      participatory_process: participatory_space
+    )
+  end
+  let(:organization) { current_component.organization }
+  let(:current_component) { create :component }
+  let(:participatory_space) { current_component.participatory_space }
+  let!(:reportables) { create_list(:dummy_resource, 2, component: current_component) }
+  let(:participatory_space_path) do
+    decidim_admin.root_path
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when the user can manage a space that has moderations" do
+    it_behaves_like "manage moderations" do
+      let(:moderations_link_text) { "Global moderations" }
+    end
+  end
+
+  context "when the user can manage a space without moderations" do
+    let(:participatory_space) do
+      create :participatory_process, organization: organization
+    end
+
+    it "can't see any moderation" do
+      visit decidim_admin.moderations_path
+
+      within ".container" do
+        expect(page).to have_content("Moderations")
+
+        expect(page).to have_no_selector("table.table-list tbody tr")
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Space moderator manages global moderations", type: :system do
+  let!(:user) do
+    create(
+      :process_moderator,
+      :confirmed,
+      organization: organization,
+      participatory_process: participatory_space
+    )
+  end
+  let(:organization) { current_component.organization }
+  let(:current_component) { create :component }
+  let(:participatory_space) { current_component.participatory_space }
+  let!(:reportables) { create_list(:dummy_resource, 2, component: current_component) }
+  let(:participatory_space_path) do
+    decidim_admin.root_path
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when the user can manage a space that has moderations" do
+    it_behaves_like "manage moderations" do
+      let(:moderations_link_text) { "Global moderations" }
+    end
+  end
+
+  context "when the user can manage a space without moderations" do
+    let(:participatory_space) do
+      create :participatory_process, organization: organization
+    end
+
+    it "can't see any moderation" do
+      visit decidim_admin.moderations_path
+
+      within ".container" do
+        expect(page).to have_content("Moderations")
+
+        expect(page).to have_no_selector("table.table-list tbody tr")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a general moderation panel in the admin section. All admin users will be able to access it, but they will only see content from the spaces they have permissions to. 

#### :pushpin: Related Issues
- Implements https://tremend.atlassian.net/browse/DIFE-334

#### Testing
Report content from a given participatory space. Then log into the admin dashboard as:

- Organization admin: you should see the reported content and be able to moderate it
- A participatory space admin with permissions to that space: you should see the reported content and be able to moderate it
- A participatory space admin with permissions for a different space: you shouldn't see the content

:hearts: Thank you!
