### PR TITLE
Add attendees count field on close meeting form

### DIFF
--- a/decidim-meetings/app/forms/decidim/meetings/admin/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/close_meeting_form.rb
@@ -19,7 +19,7 @@ module Decidim
         attribute :closed_at, Decidim::Attributes::TimeWithZone, default: ->(_form, _attribute) { Time.current }
 
         validates :closing_report, translatable_presence: true
-        validates :attendees_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+        validates :attendees_count, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 999, only_integer: true }
         validates :contributions_count, numericality: true, allow_blank: true
 
         # Private: Gets the proposals from the meeting and injects them to the form.

--- a/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
@@ -13,7 +13,7 @@ module Decidim
       validates :closing_report, presence: true
       validates :attendees_count,
                 presence: true,
-                numericality: { greater_than_or_equal_to: 0, only_integer: true }
+                numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 999, only_integer: true }
 
       # Private: Gets the proposals from the meeting and injects them to the form.
       #

--- a/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
@@ -25,7 +25,7 @@ module Decidim
       end
 
       def proposals
-        @proposals ||= Decidim.find_resource_manifest(:proposals)
+        @proposals = Decidim.find_resource_manifest(:proposals)
                               .try(:resource_scope, current_component)
                               &.where(id: proposal_ids)
                               &.order(title: :asc)

--- a/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
@@ -26,9 +26,9 @@ module Decidim
 
       def proposals
         @proposals = Decidim.find_resource_manifest(:proposals)
-                              .try(:resource_scope, current_component)
-                              &.where(id: proposal_ids)
-                              &.order(title: :asc)
+                            .try(:resource_scope, current_component)
+                            &.where(id: proposal_ids)
+                            &.order(title: :asc)
       end
     end
   end

--- a/decidim-meetings/spec/forms/close_meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/close_meeting_form_spec.rb
@@ -45,7 +45,7 @@ module Decidim::Meetings
     end
 
     describe "when attendees_count is greater than 999" do
-      let(:attendees_count) { 10000 }
+      let(:attendees_count) { 10_000 }
 
       it { is_expected.not_to be_valid }
     end

--- a/decidim-meetings/spec/forms/close_meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/close_meeting_form_spec.rb
@@ -44,6 +44,18 @@ module Decidim::Meetings
       it { is_expected.not_to be_valid }
     end
 
+    describe "when attendees_count is greater than 999" do
+      let(:attendees_count) { 10000 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when attendees_count is less than 0" do
+      let(:attendees_count) { -10 }
+
+      it { is_expected.not_to be_valid }
+    end
+
     describe "when attendees_count is invalid" do
       let(:attendees_count) { "a" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
As a user who created a meeting when closing it I’d like to be able to indicate the number of participants.

Describe the solution you'd like

Add a numerical field to the form shown to users when they close a meeting.



#### :pushpin: Related Issues
Meta proposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/16397

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Screenshot from 2021-07-15 12-28-52](https://user-images.githubusercontent.com/66411127/125765045-f7dc709f-8c8b-4956-9c43-dbb59fc00fe3.png)

:hearts: Thank you!
