### PR TITLE
Feature/proposals withdraw filter

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -51,11 +51,23 @@
     </div>
   </div>
   <div id="proposals" class="columns mediumlarge-8 large-9" aria-live="polite">
+    <% if params.dig("filter", "state").present? && params["filter"]["state"].include?("withdrawn") %>
+      <div class="callout warning">
+        <%= t(".text_banner",
+              go_back_link: link_to(t(".click_here"), proposals_path("filter[state][]" => nil)),
+            ).html_safe %>
+      </div>
+    <% end %>
     <%= render partial: "proposals" %>
   </div>
 </div>
+
 <div class="row">
   <div class="text-right">
-    <%= link_to t(".see_all_withdrawn"), proposals_path("filter[state][]" => "withdrawn") %>
+    <% if params.dig("filter", "state").present? && params["filter"]["state"].include?("withdrawn") %>
+      <%= link_to t(".see_all"), proposals_path("filter[state][]" => nil) %>
+    <% else %>
+      <%= link_to t(".see_all_withdrawn"), proposals_path("filter[state][]" => "withdrawn") %>
+    <% end %>
   </div>
 </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -754,9 +754,12 @@ en:
           filter_by: Filter by
           unfold: Unfold
         index:
+          click_here: Click here
           collaborative_drafts_list: Access collaborative drafts
           new_proposal: New proposal
+          see_all: See all proposals
           see_all_withdrawn: See all withdrawn proposals
+          text_banner: You are viewing the list of proposals withdrawn by their authors. %{go_back_link} to go back to the proposal index.
           view_proposal: View proposal
         linked_proposals:
           proposal_votes:


### PR DESCRIPTION
#### :tophat: What? Why?
When visiting the list of withdrawn proposal I don't have a link to go back to the original list.
Moreover the link a the bottom of the page "See all withdrawn proposals" just offers me to reload the same filtered view

#### :pushpin: Related Issues


#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Screenshot from 2021-08-02 18-03-04](https://user-images.githubusercontent.com/66411127/127891020-53672b94-7413-4947-bac4-1353665dbfa5.png)
![Screenshot from 2021-08-02 18-02-26](https://user-images.githubusercontent.com/66411127/127891027-2b384953-3c54-4712-a26a-fb05d2f1b550.png)

