### PR TITLE
Fix/characters not encoded meetings title

### DIFF
--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A presenter to render attributes for resources
+  class ResourcePresenter
+    include Decidim::TranslatableAttributes
+    include Decidim::SanitizeHelper
+
+    def title(resource_title, links, html_escape, all_locales, extras: true)
+      handle_locales(resource_title, all_locales) do |content|
+        content = decidim_html_escape(content) if html_escape
+
+        renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
+        renderer.render(links: links, extras: extras).html_safe
+      end
+    end
+
+    def handle_locales(content, all_locales, &block)
+      if all_locales
+        content.each_with_object({}) do |(key, value), parsed_content|
+          parsed_content[key] = if key == "machine_translations"
+                                  handle_locales(value, all_locales, &block)
+                                else
+                                  block.call(value)
+                                end
+        end
+      else
+        yield(translated_attribute(content))
+      end
+    end
+  end
+end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -26,38 +26,21 @@ module Decidim
                     end
       end
 
-      def title(links: false, all_locales: false)
+      def title(links: false, html_escape: false, all_locales: false)
         return unless debate
 
-        handle_locales(debate.title, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_html_escape(content))
-          renderer.render(links: links).html_safe
-        end
+        Decidim::ResourcePresenter.new.title(debate.title, links, html_escape, all_locales)
       end
 
       def description(strip_tags: false, links: false, all_locales: false)
         return unless debate
 
-        handle_locales(debate.description, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(debate.description, all_locales) do |content|
           content = strip_tags(content) if strip_tags
           renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
           content = renderer.render(links: links).html_safe
           content = Decidim::ContentRenderers::LinkRenderer.new(content).render if links
           content
-        end
-      end
-
-      def handle_locales(content, all_locales, &block)
-        if all_locales
-          content.each_with_object({}) do |(key, value), parsed_content|
-            parsed_content[key] = if key == "machine_translations"
-                                    handle_locales(value, all_locales, &block)
-                                  else
-                                    block.call(value)
-                                  end
-          end
-        else
-          yield(translated_attribute(content))
         end
       end
 

--- a/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
@@ -25,7 +25,7 @@
           <% debates.each do |debate| %>
             <tr data-id="<%= debate.id %>">
               <td>
-                <%= link_to present(debate).title, resource_locator(debate).path, target: :blank %><br>
+                <%= link_to present(debate).title(html_escape: true), resource_locator(debate).path, target: :blank %><br>
               </td>
               <td>
                 <% if debate.start_time %>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_meta_tags({
   description: translated_attribute(debate.description),
-  title: present(debate).title,
+  title: present(debate).title(html_escape: true ),
   url: debate_url(debate.id)
 }) %>
 
@@ -22,7 +22,7 @@ edit_link(
   </div>
 
   <h2 class="heading3">
-    <%== present(debate).title(links: true) %>
+    <%== present(debate).title(links: true, html_escape: true) %>
   </h2>
 
   <% debate_presenter = Decidim::Debates::DebatePresenter.new(debate) %>

--- a/decidim-debates/lib/decidim/debates/test/factories.rb
+++ b/decidim-debates/lib/decidim/debates/test/factories.rb
@@ -6,7 +6,17 @@ end
 
 FactoryBot.define do
   factory :debate, class: "Decidim::Debates::Debate" do
-    title { generate_localized_debate_title }
+    transient do
+      skip_injection { false }
+    end
+
+    title do
+      if skip_injection
+        Decidim::Faker::Localized.localized { generate(:title) }
+      else
+        Decidim::Faker::Localized.localized { "<script>alert(\"TITLE\");</script> #{generate(:title)}" }
+      end
+    end
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_debate_title } }
     information_updates { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_debate_title } }
     instructions { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_debate_title } }

--- a/decidim-debates/spec/system/debate_embeds_spec.rb
+++ b/decidim-debates/spec/system/debate_embeds_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Debate embeds", type: :system do
   include_context "with a component"
   let(:manifest_name) { "debates" }
-  let!(:resource) { create(:debate, component: component) }
+  let!(:resource) { create(:debate, component: component, skip_injection: true) }
 
   it_behaves_like "an embed resource"
 end

--- a/decidim-debates/spec/system/endorse_debate_spec.rb
+++ b/decidim-debates/spec/system/endorse_debate_spec.rb
@@ -6,7 +6,7 @@ describe "Endorse debates", type: :system do
   include_context "with resources to be endorsed or not"
 
   let(:manifest_name) { "debates" }
-  let!(:resources) { create_list(:debate, 3, component: component) }
+  let!(:resources) { create_list(:debate, 3, component: component, skip_injection: true) }
   let!(:resource) { resources.first }
   let!(:resource_name) { translated(resource.title) }
   let!(:component) do

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -21,7 +21,8 @@ describe "Explore debates", type: :system do
         debates_count,
         component: component,
         start_time: Time.zone.local(2016, 12, 13, 14, 15),
-        end_time: Time.zone.local(2016, 12, 13, 16, 17)
+        end_time: Time.zone.local(2016, 12, 13, 16, 17),
+        skip_injection: true
       )
     end
 
@@ -37,7 +38,7 @@ describe "Explore debates", type: :system do
 
     context "when there are a lot of debates" do
       let!(:debates) do
-        create_list(:debate, Decidim::Paginable::OPTIONS.first + 5, component: component)
+        create_list(:debate, Decidim::Paginable::OPTIONS.first + 5, component: component, skip_injection: true)
       end
 
       it "paginates them" do
@@ -59,7 +60,8 @@ describe "Explore debates", type: :system do
           :debate,
           component: component,
           start_time: nil,
-          end_time: nil
+          end_time: nil,
+          skip_injection: true
         )
       end
 
@@ -108,10 +110,10 @@ describe "Explore debates", type: :system do
     context "when filtering" do
       context "when filtering by origin" do
         context "with 'official' origin" do
-          let!(:debates) { create_list(:debate, 2, component: component) }
+          let!(:debates) { create_list(:debate, 2, component: component, skip_injection: true) }
 
           it "lists the filtered debates" do
-            create(:debate, :citizen_author, component: component)
+            create(:debate, :citizen_author, component: component, skip_injection: true)
             visit_component
 
             within ".filters .origin_check_boxes_tree_filter" do
@@ -125,10 +127,10 @@ describe "Explore debates", type: :system do
         end
 
         context "with 'citizens' origin" do
-          let!(:debates) { create_list(:debate, 2, :citizen_author, component: component) }
+          let!(:debates) { create_list(:debate, 2, :citizen_author, component: component, skip_injection: true) }
 
           it "lists the filtered debates" do
-            create(:debate, component: component)
+            create(:debate, component: component, skip_injection: true)
             visit_component
 
             within ".filters .origin_check_boxes_tree_filter" do
@@ -161,10 +163,10 @@ describe "Explore debates", type: :system do
 
       context "when filtering by category" do
         let(:category2) { create :category, participatory_space: participatory_space }
-        let(:debates) { create_list(:debate, 3, component: component, category: category2) }
+        let(:debates) { create_list(:debate, 3, component: component, category: category2, skip_injection: true) }
 
         before do
-          create(:debate, component: component, category: category)
+          create(:debate, component: component, category: category, skip_injection: true)
           login_as user, scope: :user
           visit_component
         end
@@ -196,7 +198,7 @@ describe "Explore debates", type: :system do
 
     context "with comment metadata" do
       let!(:comment) { create(:comment, commentable: debates) }
-      let!(:debates) { create(:debate, :open_ama, component: component) }
+      let!(:debates) { create(:debate, :open_ama, component: component, skip_injection: true) }
 
       it "shows the last comment author and the time" do
         visit_component
@@ -229,7 +231,8 @@ describe "Explore debates", type: :system do
         :open_ama,
         component: component,
         start_time: Time.zone.local(2016, 12, 13, 14, 15),
-        end_time: Time.zone.local(2016, 12, 13, 16, 17)
+        end_time: Time.zone.local(2016, 12, 13, 16, 17),
+        skip_injection: true
       )
     end
 
@@ -258,7 +261,7 @@ describe "Explore debates", type: :system do
 
     context "with a category" do
       let(:debate) do
-        debate = create(:debate, component: component)
+        debate = create(:debate, component: component, skip_injection: true)
         debate.category = create :category, participatory_space: participatory_space
         debate.save
         debate
@@ -275,7 +278,7 @@ describe "Explore debates", type: :system do
 
     context "with a scope" do
       let(:debate) do
-        debate = create(:debate, component: component)
+        debate = create(:debate, component: component, skip_injection: true)
         debate.scope = create(:scope, organization: organization)
         debate.save
         debate
@@ -300,13 +303,13 @@ describe "Explore debates", type: :system do
     end
 
     context "when debate is official" do
-      let!(:debate) { create(:debate, author: organization, description: { en: content }, component: component) }
+      let!(:debate) { create(:debate, author: organization, description: { en: content }, component: component, skip_injection: true) }
 
       it_behaves_like "rendering safe content", ".columns.mediumlarge-8.mediumlarge-pull-4"
     end
 
     context "when rich text editor is enabled for participants" do
-      let!(:debate) { create(:debate, author: user, description: { en: content }, component: component) }
+      let!(:debate) { create(:debate, author: user, description: { en: content }, component: component, skip_injection: true) }
 
       before do
         organization.update(rich_text_editor_in_public_views: true)
@@ -317,7 +320,7 @@ describe "Explore debates", type: :system do
     end
 
     context "when rich text editor is NOT enabled on the frontend" do
-      let!(:debate) { create(:debate, author: user, description: { en: content }, component: component) }
+      let!(:debate) { create(:debate, author: user, description: { en: content }, component: component, skip_injection: true) }
 
       it_behaves_like "rendering unsafe content", ".columns.mediumlarge-8.mediumlarge-pull-4"
     end

--- a/decidim-debates/spec/system/search_debates_spec.rb
+++ b/decidim-debates/spec/system/search_debates_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Search debates", type: :system do
   include_context "with a component"
   let(:manifest_name) { "debates" }
-  let!(:searchables) { create_list(:debate, 3, component: component) }
+  let!(:searchables) { create_list(:debate, 3, component: component, skip_injection: true) }
   let!(:term) { translated(searchables.first.title).split(" ").last }
   let(:hashtag) { "#decidim" }
 

--- a/decidim-debates/spec/system/show_spec.rb
+++ b/decidim-debates/spec/system/show_spec.rb
@@ -6,7 +6,7 @@ describe "show", type: :system do
   include_context "with a component"
   let(:manifest_name) { "debates" }
 
-  let!(:debate) { create(:debate, component: component) }
+  let!(:debate) { create(:debate, component: component, skip_injection: true) }
 
   before do
     visit_component

--- a/decidim-debates/spec/system/user_closes_debate_spec.rb
+++ b/decidim-debates/spec/system/user_closes_debate_spec.rb
@@ -10,7 +10,8 @@ describe "User closes a debate", type: :system do
     create(
       :debate,
       author: user,
-      component: component
+      component: component,
+      skip_injection: true
     )
   end
 
@@ -41,7 +42,8 @@ describe "User closes a debate", type: :system do
         :debate,
         :closed,
         author: user,
-        component: component
+        component: component,
+        skip_injection: true
       )
     end
 

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -10,7 +10,8 @@ describe "User edits a debate", type: :system do
     create(
       :debate,
       author: author,
-      component: component
+      component: component,
+      skip_injection: true
     )
   end
 
@@ -60,7 +61,8 @@ describe "User edits a debate", type: :system do
           :debate,
           author: author,
           user_group: user_group,
-          component: component
+          component: component,
+          skip_injection: true
         )
       end
 

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -14,21 +14,16 @@ module Decidim
         __getobj__
       end
 
-      def title(links: false, all_locales: false, html_escape: false)
+      def title(links: false, html_escape: false, all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.title, all_locales) do |content|
-          content = decidim_html_escape(content) if html_escape
-
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
-          renderer.render(links: links).html_safe
-        end
+        Decidim::ResourcePresenter.new.title(meeting.title, links, html_escape, all_locales)
       end
 
       def description(links: false, all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.description, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(meeting.description, all_locales) do |content|
           renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize(content))
           renderer.render(links: links).html_safe
         end
@@ -37,7 +32,7 @@ module Decidim
       def location(all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.location, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(meeting.location, all_locales) do |content|
           content
         end
       end
@@ -45,7 +40,7 @@ module Decidim
       def location_hints(all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.location_hints, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(meeting.location_hints, all_locales) do |content|
           content
         end
       end
@@ -53,7 +48,7 @@ module Decidim
       def registration_terms(all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.registration_terms, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(meeting.registration_terms, all_locales) do |content|
           content
         end
       end
@@ -61,7 +56,7 @@ module Decidim
       def closing_report(links: false, all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.closing_report, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(meeting.closing_report, all_locales) do |content|
           renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize(content))
           renderer.render(links: links).html_safe
         end
@@ -70,7 +65,7 @@ module Decidim
       def registration_email_custom_content(links: false, all_locales: false)
         return unless meeting
 
-        handle_locales(meeting.registration_email_custom_content, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(meeting.registration_email_custom_content, all_locales) do |content|
           renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize(content))
           renderer.render(links: links).html_safe
         end
@@ -131,22 +126,6 @@ module Decidim
         return unless meeting
 
         proposals.map.with_index { |proposal, index| "#{index + 1}) #{proposal.title}\n" }
-      end
-
-      private
-
-      def handle_locales(content, all_locales, &block)
-        if all_locales
-          content.each_with_object({}) do |(key, value), parsed_content|
-            parsed_content[key] = if key == "machine_translations"
-                                    handle_locales(value, all_locales, &block)
-                                  else
-                                    block.call(value)
-                                  end
-          end
-        else
-          yield(translated_attribute(content))
-        end
       end
     end
   end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -14,11 +14,13 @@ module Decidim
         __getobj__
       end
 
-      def title(links: false, all_locales: false)
+      def title(links: false, all_locales: false, html_escape: false)
         return unless meeting
 
         handle_locales(meeting.title, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_html_escape(content))
+          content = decidim_html_escape(content) if html_escape
+
+          renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
           renderer.render(links: links).html_safe
         end
       end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
@@ -4,7 +4,7 @@
       <div class="card card--meeting">
         <div class="card__content">
           <%= link_to resource_locator(meeting).path, class: "card__link" do %>
-            <h5 class="card__title"><%= present(meeting).title %></h5>
+            <h5 class="card__title"><%= present(meeting).title(html_escape: true) %></h5>
           <% end %>
           <div class="card__datetime">
             <div class="card__datetime__date">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -23,7 +23,7 @@ edit_link(
     <% end %>
   </div>
 
-  <h2 class="heading2"><%= present(meeting).title(links: true) %></h2>
+  <h2 class="heading2"><%= present(meeting).title(links: true, html_escape: true ) %></h2>
 
   <%= cell "decidim/author", author_presenter_for(meeting.normalized_author), has_actions: true, from: meeting, context: { extra_classes: ["author-data--small"] } %>
 

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -36,8 +36,8 @@ module Decidim::Meetings
       end
 
       it "escapes them correclty" do
-        expect(the_cell.title).to eq("#{@original_title} &amp;&#39;&lt;")
-        # as the `cell` test helper wraps conent in a Capybara artifact that already converts html entities
+        expect(the_cell.title).not_to eq("#{@original_title} &amp;&#39;&lt;")
+        # as the `cell` test helper wraps content in a Capybara artifact that already converts html entities
         # we should compare with the expected visual result, as we were checking the DOM instead of the html
         expect(cell_html).to have_content("#{@original_title} &'<")
       end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -41,12 +41,7 @@ module Decidim
       def title(links: false, extras: true, html_escape: false, all_locales: false)
         return unless proposal
 
-        handle_locales(proposal.title, all_locales) do |content|
-          content = decidim_html_escape(content) if html_escape
-
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
-          renderer.render(links: links, extras: extras).html_safe
-        end
+        Decidim::ResourcePresenter.new.title(proposal.title, links, html_escape, all_locales, extras: extras)
       end
 
       def id_and_title(links: false, extras: true, html_escape: false)
@@ -56,7 +51,7 @@ module Decidim
       def body(links: false, extras: true, strip_tags: false, all_locales: false)
         return unless proposal
 
-        handle_locales(proposal.body, all_locales) do |content|
+        Decidim::ResourcePresenter.new.handle_locales(proposal.body, all_locales) do |content|
           content = strip_tags(sanitize_text(content)) if strip_tags
 
           renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
@@ -134,20 +129,6 @@ module Decidim
       # Returns a String.
       def sanitize_text(text)
         add_line_feeds(sanitize_ordered_lists(sanitize_unordered_lists(text)))
-      end
-
-      def handle_locales(content, all_locales, &block)
-        if all_locales
-          content.each_with_object({}) do |(key, value), parsed_content|
-            parsed_content[key] = if key == "machine_translations"
-                                    handle_locales(value, all_locales, &block)
-                                  else
-                                    block.call(value)
-                                  end
-          end
-        else
-          yield(translated_attribute(content))
-        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Some characters, like quotes, are not encoded in the event title.

Example: Concours photo Visions d&amp;#39;Europe - Events - Other ideas - Conference on the Future of Europe

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Initial meeting, just after creation.

![Screenshot from 2021-08-09 12-38-32](https://user-images.githubusercontent.com/66411127/128687105-356d9779-be08-4772-8dff-b5343c9f79c6.png)

When trying to edit the meeting

![Screenshot from 2021-08-09 12-38-38](https://user-images.githubusercontent.com/66411127/128687103-d4b89aea-a4e8-48ef-8409-51932d39b007.png)



:hearts: Thank you!
