### PR TITLE
Fix: Initialization of autoloaded constants

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -126,6 +126,18 @@ In [\#10606](https://github.com/decidim/decidim/pull/10606) we have upgraded the
 
 Please see the [change log](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md) for graphql gem for more information.
 
+### 3.6. Orphans valuator assignments cleanup
+
+We have added a new task that helps you clean the valuator assignements records of roles that have been deleted.
+
+You can run the task with the following command:
+
+```console
+bundle exec rake decidim:proposals:upgrade:remove_valuator_orphan_records
+```
+
+You can see more details about this change on PR [\#10607](https://github.com/decidim/decidim/pull/10607)
+
 ## 4. Scheduled tasks
 
 Implementers need to configure these changes it in your scheduler task system in the production server. We give the examples

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assembly_admin.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assembly_admin.rb
@@ -23,12 +23,17 @@ module Decidim
         # Returns nothing.
         def call
           destroy_role!
+          dispatch_system_event
           broadcast(:ok)
         end
 
         private
 
         attr_reader :role, :current_user
+
+        def dispatch_system_event
+          ActiveSupport::Notifications.publish("decidim.system.participatory_space.admin.destroyed", role.class.name, role.id)
+        end
 
         def destroy_role!
           extra_info = {

--- a/decidim-assemblies/spec/commands/destroy_assembly_admin_spec.rb
+++ b/decidim-assemblies/spec/commands/destroy_assembly_admin_spec.rb
@@ -25,6 +25,16 @@ module Decidim::Assemblies
         expect { role.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      it "fires an event" do
+        expect(ActiveSupport::Notifications).to receive(:publish).with(
+          "decidim.system.participatory_space.admin.destroyed",
+          "Decidim::AssemblyUserRole",
+          role.id
+        )
+
+        subject.call
+      end
+
       it "traces the action" do
         expect(Decidim.traceability)
           .to receive(:perform_action!)

--- a/decidim-blogs/lib/decidim/blogs/engine.rb
+++ b/decidim-blogs/lib/decidim/blogs/engine.rb
@@ -28,8 +28,10 @@ module Decidim
       end
 
       initializer "decidim_blogs.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:blogs) do |transfer|
-          transfer.move_records(Decidim::Blogs::Post, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:blogs) do |transfer|
+            transfer.move_records(Decidim::Blogs::Post, :decidim_author_id)
+          end
         end
       end
     end

--- a/decidim-budgets/lib/decidim/budgets/engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/engine.rb
@@ -44,25 +44,29 @@ module Decidim
       end
 
       initializer "decidim_budgets.register_reminders" do
-        Decidim.reminders_registry.register(:orders) do |reminder_registry|
-          reminder_registry.generator_class_name = "Decidim::Budgets::OrderReminderGenerator"
-          reminder_registry.form_class_name = "Decidim::Budgets::Admin::OrderReminderForm"
-          reminder_registry.command_class_name = "Decidim::Budgets::Admin::CreateOrderReminders"
+        config.to_prepare do
+          Decidim.reminders_registry.register(:orders) do |reminder_registry|
+            reminder_registry.generator_class_name = "Decidim::Budgets::OrderReminderGenerator"
+            reminder_registry.form_class_name = "Decidim::Budgets::Admin::OrderReminderForm"
+            reminder_registry.command_class_name = "Decidim::Budgets::Admin::CreateOrderReminders"
 
-          reminder_registry.settings do |settings|
-            settings.attribute :reminder_times, type: :array, default: [2.hours, 1.week, 2.weeks]
-          end
+            reminder_registry.settings do |settings|
+              settings.attribute :reminder_times, type: :array, default: [2.hours, 1.week, 2.weeks]
+            end
 
-          reminder_registry.messages do |msg|
-            msg.set(:title) { |count: 0| I18n.t("decidim.budgets.admin.reminders.orders.title", count:) }
-            msg.set(:description) { I18n.t("decidim.budgets.admin.reminders.orders.description") }
+            reminder_registry.messages do |msg|
+              msg.set(:title) { |count: 0| I18n.t("decidim.budgets.admin.reminders.orders.title", count:) }
+              msg.set(:description) { I18n.t("decidim.budgets.admin.reminders.orders.description") }
+            end
           end
         end
       end
 
       initializer "decidim_budgets.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:budgets) do |transfer|
-          transfer.move_records(Decidim::Budgets::Order, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:budgets) do |transfer|
+            transfer.move_records(Decidim::Budgets::Order, :decidim_user_id)
+          end
         end
       end
     end

--- a/decidim-comments/lib/decidim/comments/engine.rb
+++ b/decidim-comments/lib/decidim/comments/engine.rb
@@ -72,9 +72,11 @@ module Decidim
       end
 
       initializer "decidim_comments.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:comments) do |transfer|
-          transfer.move_records(Decidim::Comments::Comment, :decidim_author_id)
-          transfer.move_records(Decidim::Comments::CommentVote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:comments) do |transfer|
+            transfer.move_records(Decidim::Comments::Comment, :decidim_author_id)
+            transfer.move_records(Decidim::Comments::CommentVote, :decidim_author_id)
+          end
         end
       end
 

--- a/decidim-conferences/app/commands/decidim/conferences/admin/destroy_conference_admin.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/destroy_conference_admin.rb
@@ -23,12 +23,17 @@ module Decidim
         # Returns nothing.
         def call
           destroy_role!
+          dispatch_system_event
           broadcast(:ok)
         end
 
         private
 
         attr_reader :role, :current_user
+
+        def dispatch_system_event
+          ActiveSupport::Notifications.publish("decidim.system.participatory_space.admin.destroyed", role.class.name, role.id)
+        end
 
         def destroy_role!
           extra_info = {

--- a/decidim-conferences/spec/commands/destroy_conference_admin_spec.rb
+++ b/decidim-conferences/spec/commands/destroy_conference_admin_spec.rb
@@ -25,6 +25,16 @@ module Decidim::Conferences
         expect { role.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      it "fires an event" do
+        expect(ActiveSupport::Notifications).to receive(:publish).with(
+          "decidim.system.participatory_space.admin.destroyed",
+          "Decidim::ConferenceUserRole",
+          role.id
+        )
+
+        subject.call
+      end
+
       it "traces the action" do
         expect(Decidim.traceability)
           .to receive(:perform_action!)

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -95,8 +95,10 @@ module Decidim
       end
 
       initializer "decidim_consultations.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:consultations) do |transfer|
-          transfer.move_records(Decidim::Consultations::Vote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:consultations) do |transfer|
+            transfer.move_records(Decidim::Consultations::Vote, :decidim_author_id)
+          end
         end
       end
     end

--- a/decidim-core/app/presenters/decidim/notification_presenter.rb
+++ b/decidim-core/app/presenters/decidim/notification_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
 
     def created_at_in_words
       if created_at.between?(1.month.ago, Time.current)
-        time_ago_in_words(created_at)
+        I18n.t("decidim.user_conversations.index.time_ago", time: time_ago_in_words(created_at))
       else
         format = created_at.year == Time.current.year ? :ddmm : :ddmmyyyy
         I18n.l(created_at, format:)

--- a/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
@@ -27,11 +27,7 @@
     <p class="conversation__item-snippet-message"><%= truncate conversation.last_message.body, length: 150 %></p>
 
     <div class="conversation__item-snippet-time">
-      <% if I18n.locale != :en %>
-        <%= t("ago", scope: "decidim.messaging.conversations.index") %> <%= time_ago_in_words(Time.zone.parse(conversation.last_message.created_at.to_s)) %>
-      <% else %>
-        <%= time_ago_in_words(Time.zone.parse(conversation.last_message.created_at.to_s)) %>
-      <% end %>
+      <%= t("decidim.user_conversations.index.time_ago", time: time_ago_in_words(Time.zone.parse(conversation.last_message.created_at.to_s))) %>
     </div>
   </div>
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -99,24 +99,26 @@ en:
         other: about %{count} months
       half_a_minute: half a minute
       less_than_x_minutes:
-        one: less than a min.
-        other: less than %{count} min.
+        one: less than a minute
+        other: less than %{count} minutes
       less_than_x_seconds:
-        one: right now
-        other: less than %{count} sec.
+        one: less than 1 second
+        other: less than %{count} seconds
       x_days:
-        one: 1 day ago
-        other: "%{count} days ago"
+        one: 1 day
+        other: "%{count} days"
       x_hours:
-        one: 1 hour ago
-        other: "%{count} hours ago"
+        one: 1 hour
+        other: "%{count} hours"
       x_minutes:
-        one: 1 min. ago
-        other: "%{count} min. ago"
+        one: 1 minute
+        other: "%{count} minutes"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
       x_seconds:
-        one: 1 sec. ago
-        other: "%{count} sec. ago"
-        zero: right now
+        one: 1 second
+        other: "%{count} seconds"
   decidim:
     accessibility:
       external_link: External link
@@ -1098,7 +1100,6 @@ en:
           intro: 'There were the following errors with your message:'
           ok: OK
         index:
-          ago: ago
           new_conversation: New conversation
           next: Next
           no_conversations: You have no conversations yet.

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -740,10 +740,12 @@ module Decidim
       end
 
       initializer "decidim.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:core) do |transfer|
-          transfer.move_records(Decidim::Coauthorship, :decidim_author_id)
-          transfer.move_records(Decidim::Endorsement, :decidim_author_id)
-          transfer.move_records(Decidim::Amendment, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:core) do |transfer|
+            transfer.move_records(Decidim::Coauthorship, :decidim_author_id)
+            transfer.move_records(Decidim::Endorsement, :decidim_author_id)
+            transfer.move_records(Decidim::Amendment, :decidim_user_id)
+          end
         end
       end
 

--- a/decidim-core/spec/presenters/decidim/notification_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/notification_presenter_spec.rb
@@ -14,33 +14,33 @@ module Decidim
       describe "#created_at_in_words" do
         context "when created_at is between zero and 59 seconds" do
           it "returns the date formated" do
-            travel_to(creating_date) { expect(subject.created_at_in_words).to eq("less than a min.") }
-            travel_to(creating_date + 1.second) { expect(subject.created_at_in_words).to eq("less than a min.") }
-            travel_to(creating_date + 10.seconds) { expect(subject.created_at_in_words).to eq("less than a min.") }
-            travel_to(creating_date + 59.seconds) { expect(subject.created_at_in_words).to eq("1 min. ago") }
+            travel_to(creating_date) { expect(subject.created_at_in_words).to eq("less than a minute ago") }
+            travel_to(creating_date + 1.second) { expect(subject.created_at_in_words).to eq("less than a minute ago") }
+            travel_to(creating_date + 10.seconds) { expect(subject.created_at_in_words).to eq("less than a minute ago") }
+            travel_to(creating_date + 59.seconds) { expect(subject.created_at_in_words).to eq("1 minute ago") }
           end
         end
 
         context "when created_at is between 1 minute and 59 minutes" do
           it "returns the date formated" do
-            travel_to(creating_date + 1.minute) { expect(subject.created_at_in_words).to eq("1 min. ago") }
-            travel_to(creating_date + 6.minutes) { expect(subject.created_at_in_words).to eq("6 min. ago") }
-            travel_to(creating_date + 59.minutes) { expect(subject.created_at_in_words).to eq("about 1 hour") }
+            travel_to(creating_date + 1.minute) { expect(subject.created_at_in_words).to eq("1 minute ago") }
+            travel_to(creating_date + 6.minutes) { expect(subject.created_at_in_words).to eq("6 minutes ago") }
+            travel_to(creating_date + 59.minutes) { expect(subject.created_at_in_words).to eq("about 1 hour ago") }
           end
         end
 
         context "when created_at is between 1 hour and 24 hours" do
           it "returns the date formated" do
-            travel_to(creating_date + 1.hour) { expect(subject.created_at_in_words).to eq("about 1 hour") }
-            travel_to(creating_date + 12.hours) { expect(subject.created_at_in_words).to eq("about 12 hours") }
-            travel_to(creating_date + 23.hours) { expect(subject.created_at_in_words).to eq("about 23 hours") }
+            travel_to(creating_date + 1.hour) { expect(subject.created_at_in_words).to eq("about 1 hour ago") }
+            travel_to(creating_date + 12.hours) { expect(subject.created_at_in_words).to eq("about 12 hours ago") }
+            travel_to(creating_date + 23.hours) { expect(subject.created_at_in_words).to eq("about 23 hours ago") }
           end
         end
 
         context "when created_at is between 1 day and 1 month" do
           it "returns the date formated" do
             travel_to(creating_date + 1.day) { expect(subject.created_at_in_words).to eq("1 day ago") }
-            travel_to(creating_date + 30.days) { expect(subject.created_at_in_words).to eq("about 1 month") }
+            travel_to(creating_date + 30.days) { expect(subject.created_at_in_words).to eq("about 1 month ago") }
           end
         end
 

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -103,8 +103,10 @@ module Decidim
       end
 
       initializer "decidim_debates.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:debates) do |transfer|
-          transfer.move_records(Decidim::Debates::Debate, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:debates) do |transfer|
+            transfer.move_records(Decidim::Debates::Debate, :decidim_author_id)
+          end
         end
       end
 

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -36,8 +36,10 @@ module Decidim
       end
 
       initializer "decidim_elections.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:elections) do |transfer|
-          transfer.move_records(Decidim::Elections::Vote, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:elections) do |transfer|
+            transfer.move_records(Decidim::Elections::Vote, :decidim_user_id)
+          end
         end
       end
     end

--- a/decidim-forms/lib/decidim/forms/engine.rb
+++ b/decidim-forms/lib/decidim/forms/engine.rb
@@ -17,8 +17,10 @@ module Decidim
       end
 
       initializer "decidim_forms.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:forms) do |transfer|
-          transfer.move_records(Decidim::Forms::Answer, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:forms) do |transfer|
+            transfer.move_records(Decidim::Forms::Answer, :decidim_user_id)
+          end
         end
       end
     end

--- a/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -9,8 +9,8 @@ module Decidim
 
       mimic :initiative
 
-      translatable_attribute :title, String
-      translatable_attribute :description, String
+      attribute :title, String
+      attribute :description, String
       attribute :type_id, Integer
       attribute :scope_id, Integer
       attribute :area_id, Integer
@@ -40,6 +40,8 @@ module Decidim
         self.type_id = model.type.id
         self.scope_id = model.scope&.id
         self.signature_type = model.signature_type
+        self.title = translated_attribute(model.title)
+        self.description = translated_attribute(model.description)
       end
 
       def signature_type_updatable?

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -140,9 +140,11 @@ module Decidim
       end
 
       initializer "decidim_initiatives.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:initiatives) do |transfer|
-          transfer.move_records(Decidim::Initiative, :decidim_author_id)
-          transfer.move_records(Decidim::InitiativesVote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:initiatives) do |transfer|
+            transfer.move_records(Decidim::Initiative, :decidim_author_id)
+            transfer.move_records(Decidim::InitiativesVote, :decidim_author_id)
+          end
         end
       end
     end

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -125,20 +125,24 @@ module Decidim
       end
 
       initializer "decidim_meetings.register_reminders" do
-        Decidim.reminders_registry.register(:close_meeting) do |reminder_registry|
-          reminder_registry.generator_class_name = "Decidim::Meetings::CloseMeetingReminderGenerator"
+        config.to_prepare do
+          Decidim.reminders_registry.register(:close_meeting) do |reminder_registry|
+            reminder_registry.generator_class_name = "Decidim::Meetings::CloseMeetingReminderGenerator"
 
-          reminder_registry.settings do |settings|
-            settings.attribute :reminder_times, type: :array, default: [3.days, 7.days]
+            reminder_registry.settings do |settings|
+              settings.attribute :reminder_times, type: :array, default: [3.days, 7.days]
+            end
           end
         end
       end
 
       initializer "decidim_meetings.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:meetings) do |transfer|
-          transfer.move_records(Decidim::Meetings::Meeting, :decidim_author_id)
-          transfer.move_records(Decidim::Meetings::Registration, :decidim_user_id)
-          transfer.move_records(Decidim::Meetings::Answer, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:meetings) do |transfer|
+            transfer.move_records(Decidim::Meetings::Meeting, :decidim_author_id)
+            transfer.move_records(Decidim::Meetings::Registration, :decidim_user_id)
+            transfer.move_records(Decidim::Meetings::Answer, :decidim_user_id)
+          end
         end
       end
 

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
@@ -13,7 +13,7 @@ module Decidim
       end
 
       def current_filter
-        get_filter(:with_date, model[:default_filter])
+        get_filter_in(:with_date, ALL_FILTERS, model[:default_filter])
       end
 
       def current_type_filter_name
@@ -23,6 +23,11 @@ module Decidim
 
       def get_filter(filter_name, default = nil)
         params&.dig(:filter, filter_name) || default
+      end
+
+      def get_filter_in(filter_name, options, default = nil)
+        value = get_filter(filter_name)
+        options.include?(value) ? value : default
       end
 
       def filter_params(date_filter, type_filter)

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_admin.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_admin.rb
@@ -23,12 +23,17 @@ module Decidim
         # Returns nothing.
         def call
           destroy_role!
+          dispatch_system_event
           broadcast(:ok)
         end
 
         private
 
         attr_reader :role, :current_user
+
+        def dispatch_system_event
+          ActiveSupport::Notifications.publish("decidim.system.participatory_space.admin.destroyed", role.class.name, role.id)
+        end
 
         def destroy_role!
           extra_info = {

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/process_filters_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/process_filters_cell_spec.rb
@@ -10,17 +10,51 @@ module Decidim::ParticipatoryProcesses
     let!(:participatory_process_list1) { create_list(:participatory_process, 2, :published, organization: organization1) }
     let!(:participatory_process_list2) { create_list(:participatory_process, 2, :published, organization: organization2) }
 
-    subject { cell("decidim/participatory_processes/process_filters", default_filter: "active") }
+    let(:my_cell) { cell("decidim/participatory_processes/process_filters", default_filter:) }
+    let(:default_filter) { "active" }
+    let(:filter_params) { { with_date: "all" } }
+
+    subject { my_cell }
     controller Decidim::ParticipatoryProcesses::ParticipatoryProcessesController
 
     before do
       allow(controller).to receive(:current_organization).and_return(organization1)
-      allow(subject).to receive(:controller).and_return(controller)
-      allow(subject).to receive(:params).and_return(ActionController::Parameters.new({ filter: { with_date: "all" } }))
+      allow(my_cell).to receive(:controller).and_return(controller)
+      allow(my_cell).to receive(:params).and_return(ActionController::Parameters.new({ filter: filter_params }))
     end
 
     it "counts the processes" do
       expect(subject.filtered_processes("all", filter_with_type: false).count).to eq(2)
+    end
+
+    describe "#current_filter" do
+      subject { my_cell.current_filter }
+
+      let(:filter_params) { { with_date: date_filter } }
+
+      shared_examples "expected current_filter value" do |given_value|
+        let(:date_filter) { given_value }
+
+        it { is_expected.to eq(given_value) }
+      end
+
+      shared_examples "unexpected current_filter_value" do |given_value|
+        let(:date_filter) { given_value }
+
+        it { is_expected.to eq(default_filter) }
+      end
+
+      it_behaves_like "expected current_filter value", "active"
+      it_behaves_like "expected current_filter value", "upcoming"
+      it_behaves_like "expected current_filter value", "past"
+      it_behaves_like "expected current_filter value", "all"
+
+      it_behaves_like "unexpected current_filter_value", nil
+      it_behaves_like "unexpected current_filter_value", ["upcoming"]
+      it_behaves_like "unexpected current_filter_value", { 1 => "upcoming" }
+      it_behaves_like "unexpected current_filter_value", "unknown"
+      it_behaves_like "unexpected current_filter_value", "upcomingfoobar"
+      it_behaves_like "unexpected current_filter_value", "upcoming foobar"
     end
   end
 end

--- a/decidim-participatory_processes/spec/commands/destroy_participatory_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/commands/destroy_participatory_process_admin_spec.rb
@@ -25,6 +25,16 @@ module Decidim::ParticipatoryProcesses
         expect { role.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
+      it "fires an event" do
+        expect(ActiveSupport::Notifications).to receive(:publish).with(
+          "decidim.system.participatory_space.admin.destroyed",
+          "Decidim::ParticipatoryProcessUserRole",
+          role.id
+        )
+
+        subject.call
+      end
+
       it "traces the action" do
         expect(Decidim.traceability)
           .to receive(:perform_action!)

--- a/decidim-participatory_processes/spec/requests/participatory_process_search_spec.rb
+++ b/decidim-participatory_processes/spec/requests/participatory_process_search_spec.rb
@@ -117,5 +117,22 @@ RSpec.describe "Participatory process search", type: :request do
         expect(subject).to include(translated(upcoming_process.title))
       end
     end
+
+    context "and the date is set to an unknown value" do
+      let(:date) { "foobar" }
+      let(:dom) { Nokogiri::HTML(subject) }
+
+      it "displays all public processes" do
+        expect(subject).to include(translated(process1.title))
+        expect(subject).to include(translated(process2.title))
+        expect(subject).to include(translated(past_process.title))
+        expect(subject).to include(translated(upcoming_process.title))
+      end
+
+      it "does not cause any display issues" do
+        expect(dom.css("#processes-grid .processes-grid-order-by .section-heading").text).to include("2 active processes")
+        expect(dom.css("#processes-grid .processes-grid-order-by .section-heading").text).not_to include("foobar")
+      end
+    end
   end
 end

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "decidim-admin", Decidim::Proposals.version
   s.add_development_dependency "decidim-assemblies", Decidim::Proposals.version
   s.add_development_dependency "decidim-budgets", Decidim::Proposals.version
+  s.add_development_dependency "decidim-conference", Decidim::Proposals.version
   s.add_development_dependency "decidim-dev", Decidim::Proposals.version
   s.add_development_dependency "decidim-meetings", Decidim::Proposals.version
   s.add_development_dependency "decidim-participatory_processes", Decidim::Proposals.version

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -90,6 +90,12 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Proposals::Engine.root}/app/views") # for proposal partials
       end
 
+      initializer "decidim_proposals.remove_space_admins" do
+        ActiveSupport::Notifications.subscribe("decidim.system.participatory_space.admin.destroyed") do |_event_name, klass, id|
+          Decidim::Proposals::ValuationAssignment.where(valuator_role_type: klass, valuator_role_id: id).destroy_all
+        end
+      end
+
       initializer "decidim_proposals.add_badges" do
         Decidim::Gamification.register_badge(:proposals) do |badge|
           badge.levels = [1, 5, 10, 30, 60]

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -210,8 +210,10 @@ module Decidim
       end
 
       initializer "decidim_proposals.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:proposals) do |transfer|
-          transfer.move_records(Decidim::Proposals::ProposalVote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:proposals) do |transfer|
+            transfer.move_records(Decidim::Proposals::ProposalVote, :decidim_author_id)
+          end
         end
       end
 

--- a/decidim-proposals/lib/tasks/proposals/upgrade/decdim_proposal_upgrade_tasks.rake
+++ b/decidim-proposals/lib/tasks/proposals/upgrade/decdim_proposal_upgrade_tasks.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :proposals do
+    namespace :upgrade do
+      desc "Removes all proposal valuator records of which the role assignment does not exists"
+      task remove_valuator_orphan_records: :environment do
+        if Decidim.module_installed?("participatory_processes")
+          Decidim::Proposals::ValuationAssignment
+            .where(valuator_role_type: "Decidim::ParticipatoryProcessUserRole")
+            .where
+            .not(valuator_role_id: Decidim::ParticipatoryProcessUserRole.pluck(:id))
+            .destroy_all
+        end
+
+        if Decidim.module_installed?("assemblies")
+          Decidim::Proposals::ValuationAssignment
+            .where(valuator_role_type: "Decidim::AssemblyUserRole")
+            .where
+            .not(valuator_role_id: Decidim::AssemblyUserRole.pluck(:id))
+            .destroy_all
+        end
+
+        if Decidim.module_installed?("conferences")
+          Decidim::Proposals::ValuationAssignment
+            .where(valuator_role_type: "Decidim::ConferenceUserRole")
+            .where
+            .not(valuator_role_id: Decidim::ConferenceUserRole.pluck(:id))
+            .destroy_all
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/factories.rb
+++ b/decidim-proposals/spec/factories.rb
@@ -3,6 +3,7 @@
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/assemblies/test/factories"
+require "decidim/conferences/test/factories"
 require "decidim/comments/test/factories"
 require "decidim/meetings/test/factories"
 require "decidim/budgets/test/factories"

--- a/decidim-proposals/spec/lib/decidim/proposals/engine_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/engine_spec.rb
@@ -3,6 +3,48 @@
 require "spec_helper"
 
 describe Decidim::Proposals::Engine do
+  describe "decidim_proposals.remove_space_admins" do
+    let(:component) { create(:proposal_component, participatory_space: space) }
+    let(:valuator) { create :user, organization: }
+    let(:proposal) { create(:proposal, component:) }
+
+    context "when removing participatory_space admin" do
+      let(:space) { valuator_role.participatory_process }
+      let(:valuator_role) { create(:participatory_process_user_role) }
+      let!(:assignment) { create :valuation_assignment, proposal:, valuator_role: }
+
+      it "removes the record" do
+        expect do
+          ActiveSupport::Notifications.publish("decidim.system.participatory_space.admin.destroyed", valuator_role.class.name, valuator_role.id)
+        end.to change(Decidim::Proposals::ValuationAssignment, :count).by(-1)
+      end
+    end
+
+    context "when removing assembly admin" do
+      let(:space) { valuator_role.assembly }
+      let(:valuator_role) { create(:assembly_user_role) }
+      let!(:assignment) { create :valuation_assignment, proposal:, valuator_role: }
+
+      it "removes the record" do
+        expect do
+          ActiveSupport::Notifications.publish("decidim.system.participatory_space.admin.destroyed", valuator_role.class.name, valuator_role.id)
+        end.to change(Decidim::Proposals::ValuationAssignment, :count).by(-1)
+      end
+    end
+
+    context "when removing conference admin" do
+      let(:space) { valuator_role.conference }
+      let(:valuator_role) { create(:conference_user_role) }
+      let!(:assignment) { create :valuation_assignment, proposal:, valuator_role: }
+
+      it "removes the record" do
+        expect do
+          ActiveSupport::Notifications.publish("decidim.system.participatory_space.admin.destroyed", valuator_role.class.name, valuator_role.id)
+        end.to change(Decidim::Proposals::ValuationAssignment, :count).by(-1)
+      end
+    end
+  end
+
   describe "decidim_proposals.authorization_transfer" do
     include_context "authorization transfer"
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
When `spring` is booting, there are a few warnings regarding the autoloaded constants beings deprecated. This PR is trying to fix this. 

```
DEPRECATION WARNING: Initialization autoloaded the constants Decidim::ApplicationRecord, Decidim::AuthorizationTransfer, Decidim::Meetings::CloseMeetingReminderGenerator, and Decidim::Budgets::OrderReminderGenerator.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Decidim::ApplicationRecord, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.

```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
