### PR TITLE
Fix rubocop rules 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,9 +119,6 @@ RSpec/Rails/TravelAround:
 Style/EachForSimpleLoop:
   Enabled: false
 
-RSpec/ContextWording:
-  Enabled: false
-
 Rails/ActiveSupportOnLoad:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,9 +131,6 @@ RSpec/Rails/HaveHttpStatus:
 Rails/HelperInstanceVariable:
   Enabled: false
 
-RSpec/BeEmpty:
-  Enabled: false
-
 Rails/RootPathnameMethods:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,7 +119,4 @@ RSpec/SkipBlockInsideExample:
 Rails/HelperInstanceVariable:
   Enabled: false
 
-Rails/RootPathnameMethods:
-  Enabled: false
-
 # EOF fix these rules later

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,9 +68,6 @@ Style/RedundantStringEscape:
 Style/MapToSet:
   Enabled: false
 
-Style/HashSyntax:
-  Enabled: false
-
 Style/Semicolon:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,9 +125,6 @@ Rails/ActiveSupportOnLoad:
 RSpec/SkipBlockInsideExample:
   Enabled: false
 
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-
 Rails/HelperInstanceVariable:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,9 +113,6 @@ Rails/ActionControllerFlashBeforeRender:
 RSpec/ContainExactly:
   Enabled: false
 
-RSpec/Rails/TravelAround:
-  Enabled: false
-
 Style/EachForSimpleLoop:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -122,9 +122,6 @@ Style/EachForSimpleLoop:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: false
-
 Rails/ActiveSupportOnLoad:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,9 +110,6 @@ RSpec/MatchArray:
 Rails/ActionControllerFlashBeforeRender:
   Enabled: false
 
-RSpec/ContainExactly:
-  Enabled: false
-
 Style/EachForSimpleLoop:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,9 +119,6 @@ RSpec/Rails/TravelAround:
 Style/EachForSimpleLoop:
   Enabled: false
 
-Rails/ActiveSupportOnLoad:
-  Enabled: false
-
 RSpec/SkipBlockInsideExample:
   Enabled: false
 

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
@@ -43,13 +43,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :result, result: result
+          enforce_permission_to(:update, :result, result:)
 
           @form = form(ResultForm).from_model(result)
         end
 
         def update
-          enforce_permission_to :update, :result, result: result
+          enforce_permission_to(:update, :result, result:)
 
           @form = form(ResultForm).from_params(params)
 
@@ -67,7 +67,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :result, result: result
+          enforce_permission_to(:destroy, :result, result:)
 
           DestroyResult.call(result, current_user) do
             on(:ok) do

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
@@ -32,13 +32,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :status, status: status
+          enforce_permission_to(:update, :status, status:)
 
           @form = form(StatusForm).from_model(status)
         end
 
         def update
-          enforce_permission_to :update, :status, status: status
+          enforce_permission_to(:update, :status, status:)
 
           @form = form(StatusForm).from_params(params)
 
@@ -56,7 +56,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :status, status: status
+          enforce_permission_to(:destroy, :status, status:)
 
           Decidim.traceability.perform_action!("delete", status, current_user) do
             status.destroy!

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/timeline_entries_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/timeline_entries_controller.rb
@@ -33,13 +33,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :timeline_entry, timeline_entry: timeline_entry
+          enforce_permission_to(:update, :timeline_entry, timeline_entry:)
 
           @form = form(TimelineEntryForm).from_model(timeline_entry)
         end
 
         def update
-          enforce_permission_to :update, :timeline_entry, timeline_entry: timeline_entry
+          enforce_permission_to(:update, :timeline_entry, timeline_entry:)
 
           @form = form(TimelineEntryForm).from_params(params)
 
@@ -57,7 +57,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :timeline_entry, timeline_entry: timeline_entry
+          enforce_permission_to(:destroy, :timeline_entry, timeline_entry:)
 
           Decidim.traceability.perform_action!("delete", timeline_entry, current_user) do
             timeline_entry.destroy!

--- a/decidim-accountability/spec/requests/result_search_spec.rb
+++ b/decidim-accountability/spec/requests/result_search_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Result search", type: :request do
     context "when deep searching" do
       context "when the parent_id is nil" do
         it "returns the search on all results" do
-          expect(subject).to match_array [result1, result2, result4]
+          expect(subject).to contain_exactly(result1, result2, result4)
         end
       end
 
@@ -85,7 +85,7 @@ RSpec.describe "Result search", type: :request do
         let(:parent_id) { result1.id }
 
         it "returns the search on the children of result" do
-          expect(subject).to match_array [result2, result3]
+          expect(subject).to contain_exactly(result2, result3)
         end
       end
 
@@ -93,7 +93,7 @@ RSpec.describe "Result search", type: :request do
         let(:parent_id) { result2.id }
 
         it "returns the search on the children of result" do
-          expect(subject).to match_array [result3]
+          expect(subject).to contain_exactly(result3)
         end
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe "Result search", type: :request do
       let(:filter_params) { { search_text_cont: "doggo" } }
 
       it "returns the search results matching the word in title or description" do
-        expect(subject).to match_array [result1, result2]
+        expect(subject).to contain_exactly(result1, result2)
       end
     end
   end

--- a/decidim-accountability/spec/services/decidim/accountability/diff_renderer_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/diff_renderer_spec.rb
@@ -26,7 +26,7 @@ describe Decidim::Accountability::DiffRenderer, versioning: true do
 
     it "calculates the fields that have changed" do
       expect(subject.keys)
-        .to match_array [:title_en, :description_ca, :progress, :start_date]
+        .to contain_exactly(:title_en, :description_ca, :progress, :start_date)
     end
 
     it "has the old and new values for each field" do

--- a/decidim-accountability/spec/services/decidim/accountability/searchable_result_resource_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/searchable_result_resource_spec.rb
@@ -95,7 +95,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[result.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [result, result2]
+              expect(results[:results]).to contain_exactly(result, result2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -229,7 +229,7 @@ describe "Explore results", versioning: true, type: :system do
     context "with a scope" do
       let(:result) do
         result = results.first
-        result.scope = create :scope, organization: organization
+        result.scope = create(:scope, organization:)
         result.save
         result
       end

--- a/decidim-admin/app/controllers/decidim/admin/area_types_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/area_types_controller.rb
@@ -35,12 +35,12 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :update, :area_type, area_type: area_type
+        enforce_permission_to(:update, :area_type, area_type:)
         @form = form(AreaTypeForm).from_model(area_type)
       end
 
       def update
-        enforce_permission_to :update, :area_type, area_type: area_type
+        enforce_permission_to(:update, :area_type, area_type:)
         @form = form(AreaTypeForm).from_params(params)
 
         UpdateAreaType.call(area_type, @form, current_user) do
@@ -57,7 +57,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :destroy, :area_type, area_type: area_type
+        enforce_permission_to(:destroy, :area_type, area_type:)
 
         Decidim.traceability.perform_action!("delete", area_type, current_user) do
           area_type.destroy!

--- a/decidim-admin/app/controllers/decidim/admin/areas_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/areas_controller.rb
@@ -35,12 +35,12 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :update, :area, area: area
+        enforce_permission_to(:update, :area, area:)
         @form = form(AreaForm).from_model(area)
       end
 
       def update
-        enforce_permission_to :update, :area, area: area
+        enforce_permission_to(:update, :area, area:)
         @form = form(AreaForm).from_params(params)
 
         UpdateArea.call(area, @form) do
@@ -57,7 +57,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :destroy, :area, area: area
+        enforce_permission_to(:destroy, :area, area:)
 
         DestroyArea.call(area, current_user) do
           on(:ok) do

--- a/decidim-admin/app/controllers/decidim/admin/component_permissions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/component_permissions_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       include Decidim::ComponentPathHelper
 
       def edit
-        enforce_permission_to :update, :component, component: component
+        enforce_permission_to(:update, :component, component:)
         @permissions_form = PermissionsForm.new(
           permissions: permission_forms
         )
@@ -17,7 +17,7 @@ module Decidim
       end
 
       def update
-        enforce_permission_to :update, :component, component: component
+        enforce_permission_to(:update, :component, component:)
         @permissions_form = PermissionsForm.from_params(params)
 
         UpdateComponentPermissions.call(@permissions_form, component, resource, current_user) do

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb
@@ -16,19 +16,19 @@ module Decidim
           helper_method :attached_to, :attachment
 
           def index
-            enforce_permission_to :read, :attachment, attached_to: attached_to
+            enforce_permission_to(:read, :attachment, attached_to:)
 
             render template: "decidim/admin/attachments/index"
           end
 
           def new
-            enforce_permission_to :create, :attachment, attached_to: attached_to
+            enforce_permission_to(:create, :attachment, attached_to:)
             @form = form(::Decidim::Admin::AttachmentForm).from_params({}, attached_to:)
             render template: "decidim/admin/attachments/new"
           end
 
           def create
-            enforce_permission_to :create, :attachment, attached_to: attached_to
+            enforce_permission_to(:create, :attachment, attached_to:)
             @form = form(::Decidim::Admin::AttachmentForm).from_params(params, attached_to:)
 
             CreateAttachment.call(@form, attached_to, current_user) do
@@ -46,14 +46,14 @@ module Decidim
 
           def edit
             @attachment = collection.find(params[:id])
-            enforce_permission_to :update, :attachment, attachment: attachment
+            enforce_permission_to(:update, :attachment, attachment:)
             @form = form(::Decidim::Admin::AttachmentForm).from_model(@attachment, attached_to:)
             render template: "decidim/admin/attachments/edit"
           end
 
           def update
             @attachment = collection.find(params[:id])
-            enforce_permission_to :update, :attachment, attachment: attachment
+            enforce_permission_to(:update, :attachment, attachment:)
             @form = form(::Decidim::Admin::AttachmentForm).from_params(attachment_params, attached_to:)
 
             UpdateAttachment.call(@attachment, @form, current_user) do
@@ -71,13 +71,13 @@ module Decidim
 
           def show
             @attachment = collection.find(params[:id])
-            enforce_permission_to :read, :attachment, attachment: attachment
+            enforce_permission_to(:read, :attachment, attachment:)
             render template: "decidim/admin/attachments/show"
           end
 
           def destroy
             @attachment = collection.find(params[:id])
-            enforce_permission_to :destroy, :attachment, attachment: attachment
+            enforce_permission_to(:destroy, :attachment, attachment:)
 
             Decidim.traceability.perform_action!("delete", @attachment, current_user) do
               @attachment.destroy!

--- a/decidim-admin/app/controllers/decidim/admin/exports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/exports_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::ComponentPathHelper
 
       def create
-        enforce_permission_to :export, :component_data, component: component
+        enforce_permission_to(:export, :component_data, component:)
         name = params[:id]
 
         Decidim.traceability.perform_action!("export_component", component, current_user, { name:, format: params[:format] || default_format }) do

--- a/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
@@ -12,7 +12,7 @@ module Decidim
                     :creating_managed_user?
 
       def new
-        enforce_permission_to :impersonate, :impersonatable_user, user: user
+        enforce_permission_to(:impersonate, :impersonatable_user, user:)
 
         @form = form(ImpersonateUserForm).from_params(
           user:,
@@ -25,7 +25,7 @@ module Decidim
       end
 
       def create
-        enforce_permission_to :impersonate, :impersonatable_user, user: user
+        enforce_permission_to(:impersonate, :impersonatable_user, user:)
 
         @form = form(ImpersonateUserForm).from_params(
           user:,

--- a/decidim-admin/app/controllers/decidim/admin/managed_users/promotions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users/promotions_controller.rb
@@ -9,12 +9,12 @@ module Decidim
         layout "decidim/admin/users"
 
         def new
-          enforce_permission_to :promote, :managed_user, user: user
+          enforce_permission_to(:promote, :managed_user, user:)
           @form = form(ManagedUserPromotionForm).instance
         end
 
         def create
-          enforce_permission_to :promote, :managed_user, user: user
+          enforce_permission_to(:promote, :managed_user, user:)
           @form = form(ManagedUserPromotionForm).from_params(params)
 
           PromoteManagedUser.call(@form, user, current_user) do

--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -21,12 +21,12 @@ module Decidim
       end
 
       def show
-        enforce_permission_to :read, :newsletter, newsletter: newsletter
+        enforce_permission_to(:read, :newsletter, newsletter:)
         @email = NewsletterMailer.newsletter(current_user, newsletter)
       end
 
       def preview
-        enforce_permission_to :read, :newsletter, newsletter: newsletter
+        enforce_permission_to(:read, :newsletter, newsletter:)
 
         email = NewsletterMailer.newsletter(current_user, newsletter, preview: true)
         Premailer::Rails::Hook.perform(email)
@@ -53,12 +53,12 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :update, :newsletter, newsletter: newsletter
+        enforce_permission_to(:update, :newsletter, newsletter:)
         @form = form(NewsletterForm).from_model(content_block)
       end
 
       def update
-        enforce_permission_to :update, :newsletter, newsletter: newsletter
+        enforce_permission_to(:update, :newsletter, newsletter:)
         @form = form(NewsletterForm).from_params(params)
         @form.images = images_block_context unless has_images_block_context?
 
@@ -77,7 +77,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :destroy, :newsletter, newsletter: newsletter
+        enforce_permission_to(:destroy, :newsletter, newsletter:)
 
         DestroyNewsletter.call(newsletter, current_user) do
           on(:already_sent) do
@@ -93,7 +93,7 @@ module Decidim
       end
 
       def select_recipients_to_deliver
-        enforce_permission_to :update, :newsletter, newsletter: newsletter
+        enforce_permission_to(:update, :newsletter, newsletter:)
         @form = form(SelectiveNewsletterForm).from_model(newsletter)
         @form.send_to_all_users = current_user.admin?
       end
@@ -105,7 +105,7 @@ module Decidim
       end
 
       def deliver
-        enforce_permission_to :update, :newsletter, newsletter: newsletter
+        enforce_permission_to(:update, :newsletter, newsletter:)
         @form = form(SelectiveNewsletterForm).from_params(params)
 
         DeliverNewsletter.call(newsletter, @form, current_user) do

--- a/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/officializations_controller.rb
@@ -50,7 +50,7 @@ module Decidim
       end
 
       def show_email
-        enforce_permission_to :show_email, :user, user: user
+        enforce_permission_to(:show_email, :user, user:)
 
         Decidim.traceability.perform_action! :show_email, user, current_user
 

--- a/decidim-admin/app/controllers/decidim/admin/scope_types_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scope_types_controller.rb
@@ -35,12 +35,12 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :update, :scope_type, scope_type: scope_type
+        enforce_permission_to(:update, :scope_type, scope_type:)
         @form = form(ScopeTypeForm).from_model(scope_type)
       end
 
       def update
-        enforce_permission_to :update, :scope_type, scope_type: scope_type
+        enforce_permission_to(:update, :scope_type, scope_type:)
         @form = form(ScopeTypeForm).from_params(params)
 
         UpdateScopeType.call(scope_type, @form, current_user) do
@@ -57,7 +57,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :destroy, :scope_type, scope_type: scope_type
+        enforce_permission_to(:destroy, :scope_type, scope_type:)
 
         Decidim.traceability.perform_action!("delete", scope_type, current_user) do
           scope_type.destroy!

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -36,12 +36,12 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :update, :scope, scope: scope
+        enforce_permission_to(:update, :scope, scope:)
         @form = form(ScopeForm).from_model(scope)
       end
 
       def update
-        enforce_permission_to :update, :scope, scope: scope
+        enforce_permission_to(:update, :scope, scope:)
         @form = form(ScopeForm).from_params(params)
 
         UpdateScope.call(scope, @form) do
@@ -58,7 +58,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :destroy, :scope, scope: scope
+        enforce_permission_to(:destroy, :scope, scope:)
 
         DestroyScope.call(scope, current_user) do
           on(:ok) do

--- a/decidim-admin/app/controllers/decidim/admin/share_tokens_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/share_tokens_controller.rb
@@ -4,7 +4,7 @@ module Decidim
   module Admin
     class ShareTokensController < Decidim::Admin::ApplicationController
       def destroy
-        enforce_permission_to :destroy, :share_token, share_token: share_token
+        enforce_permission_to(:destroy, :share_token, share_token:)
 
         DestroyShareToken.call(share_token, current_user) do
           on(:ok) do

--- a/decidim-admin/app/controllers/decidim/admin/users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/users_controller.rb
@@ -42,7 +42,7 @@ module Decidim
       end
 
       def resend_invitation
-        enforce_permission_to :invite, :admin_user, user: user
+        enforce_permission_to(:invite, :admin_user, user:)
 
         InviteUserAgain.call(user, "invite_admin") do
           on(:ok) do
@@ -58,7 +58,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :destroy, :admin_user, user: user
+        enforce_permission_to(:destroy, :admin_user, user:)
 
         RemoveAdmin.call(user, current_user) do
           on(:ok) do

--- a/decidim-admin/app/helpers/decidim/admin/imports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/imports_helper.rb
@@ -13,7 +13,7 @@ module Decidim
       #
       # Returns a rendered dropdown.
       def import_dropdown(component = current_component, resource_id: nil)
-        render "decidim/admin/imports/dropdown", component: component, resource_id: resource_id, custom: block_given? do
+        render "decidim/admin/imports/dropdown", component:, resource_id:, custom: block_given? do
           yield if block_given?
         end
       end

--- a/decidim-admin/spec/commands/decidim/admin/publish_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/publish_component_spec.rb
@@ -27,7 +27,7 @@ module Decidim::Admin
     end
 
     it "fires an event" do
-      create(:follow, followable: participatory_process, user: user)
+      create(:follow, followable: participatory_process, user:)
 
       expect(Decidim::EventsManager)
         .to receive(:publish)

--- a/decidim-admin/spec/controllers/impersonations_controller_spec.rb
+++ b/decidim-admin/spec/controllers/impersonations_controller_spec.rb
@@ -23,7 +23,7 @@ module Decidim
       context "when creating a new impersonation" do
         shared_examples "successful authorization" do
           it "successfully creates a new impersonation log entry and redirects to home" do
-            post :create, params: params
+            post(:create, params:)
 
             authorization = Decidim::Authorization.last
             expect(Decidim::ImpersonationLog.where(
@@ -60,7 +60,7 @@ module Decidim
           it_behaves_like "successful authorization"
 
           it "creates a new managed user with the correct authorization" do
-            post :create, params: params
+            post(:create, params:)
 
             authorization = Decidim::Authorization.last
             expect(authorization.metadata).to include(
@@ -83,7 +83,7 @@ module Decidim
           it_behaves_like "successful authorization"
 
           it "creates a new managed user" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(Decidim::User.where(name: managed_user_name).count).to eq(2)
             expect(
@@ -108,7 +108,7 @@ module Decidim
           it_behaves_like "successful authorization"
 
           it "creates a new managed user" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(
               Decidim::User.where(
@@ -141,7 +141,7 @@ module Decidim
           it_behaves_like "successful authorization"
 
           it "takes control of the previously identified managed user and updates the metadata" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(
               Decidim::User.where(
@@ -177,7 +177,7 @@ module Decidim
           end
 
           it "fails the authorization" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(
               Decidim::User.where(

--- a/decidim-admin/spec/queries/newsletter_recipients_spec.rb
+++ b/decidim-admin/spec/queries/newsletter_recipients_spec.rb
@@ -178,7 +178,7 @@ module Decidim::Admin
           end
 
           it "do not return recipients" do
-            expect(subject.query).to match_array []
+            expect(subject.query).to be_empty
           end
         end
       end

--- a/decidim-admin/spec/queries/user_filter_spec.rb
+++ b/decidim-admin/spec/queries/user_filter_spec.rb
@@ -32,7 +32,7 @@ module Decidim::Admin
           let(:search) { "Argo" }
 
           it "returns all matching users" do
-            expect(subject.query).to match_array([users[1], users[2]])
+            expect(subject.query).to contain_exactly(users[1], users[2])
           end
         end
 
@@ -111,7 +111,7 @@ module Decidim::Admin
         let(:filter) { "officialized" }
 
         it 'returns the "Officialized" users that contain the query search' do
-          expect(subject.query).to match_array([officialized_users[0], officialized_users[2]])
+          expect(subject.query).to contain_exactly(officialized_users[0], officialized_users[2])
         end
       end
     end

--- a/decidim-admin/spec/queries/user_group_evaluation_spec.rb
+++ b/decidim-admin/spec/queries/user_group_evaluation_spec.rb
@@ -31,7 +31,7 @@ module Decidim::Admin
           let(:search) { "Argo" }
 
           it "returns all matching users" do
-            expect(subject.query).to match_array([user_groups[1], user_groups[2]])
+            expect(subject.query).to contain_exactly(user_groups[1], user_groups[2])
           end
         end
 
@@ -98,7 +98,7 @@ module Decidim::Admin
         end
 
         it 'returns the "Rejected" user groups that contain the query search' do
-          expect(subject.query).to match_array([rejected_user_groups[0], rejected_user_groups[2]])
+          expect(subject.query).to contain_exactly(rejected_user_groups[0], rejected_user_groups[2])
         end
       end
     end

--- a/decidim-admin/spec/system/admin_checks_metrics_spec.rb
+++ b/decidim-admin/spec/system/admin_checks_metrics_spec.rb
@@ -13,7 +13,7 @@ describe "Admin checks metrics", type: :system do
     login_as user, scope: :user
 
     metric_manifests.each do |manifest|
-      create(:metric, organization: organization, metric_type: manifest.metric_name, day: Time.zone.today)
+      create(:metric, organization:, metric_type: manifest.metric_name, day: Time.zone.today)
       create(:metric, organization:, metric_type: manifest.metric_name, day: Time.zone.yesterday)
     end
 

--- a/decidim-admin/spec/system/participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/system/participatory_space_private_user_spec.rb
@@ -10,7 +10,7 @@ describe "Admin checks pagination on participatory space private users", type: :
 
   before do
     (0..20).each do |_i|
-      user = create(:user, organization: organization)
+      user = create(:user, organization:)
       create(:assembly_private_user, user:, privatable_to: assembly)
     end
     switch_to_host(organization.host)

--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -60,23 +60,18 @@ module Decidim
 
         it "includes only published assemblies with their children (two levels)" do
           get :index, format: :json
-          expect(parsed_response).to match_array(
-            [
-              {
-                name: translated(promoted.title),
-                children: []
-              },
-              {
-                name: translated(published.title),
-                children: [
-                  {
-                    name: translated(first_level.title),
-                    children: [{ name: translated(second_level.title) }]
-                  }
-                ]
-              }
-            ]
-          )
+          expect(parsed_response).to contain_exactly({
+                                                       name: translated(promoted.title),
+                                                       children: []
+                                                     }, {
+                                                       name: translated(published.title),
+                                                       children: [
+                                                         {
+                                                           name: translated(first_level.title),
+                                                           children: [{ name: translated(second_level.title) }]
+                                                         }
+                                                       ]
+                                                     })
         end
       end
 

--- a/decidim-assemblies/spec/controllers/assembly_members_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assembly_members_controller_spec.rb
@@ -38,7 +38,7 @@ module Decidim
             it "displays list of members" do
               get :index, params: { assembly_slug: assembly.slug }
 
-              expect(controller.helpers.collection).to match_array([member1, member2])
+              expect(controller.helpers.collection).to contain_exactly(member1, member2)
             end
           end
 

--- a/decidim-assemblies/spec/models/decidim/assemblies_type_spec.rb
+++ b/decidim-assemblies/spec/models/decidim/assemblies_type_spec.rb
@@ -31,7 +31,7 @@ module Decidim
 
       let(:assemblies) { create_list(:assembly, 2, assembly_type: assemblies_type) }
 
-      it { is_expected.to contain_exactly(*assemblies) }
+      it { is_expected.to match_array(assemblies) }
     end
   end
 end

--- a/decidim-assemblies/spec/queries/admin/assembly_admins_spec.rb
+++ b/decidim-assemblies/spec/queries/admin/assembly_admins_spec.rb
@@ -17,14 +17,14 @@ module Decidim::Assemblies::Admin
     let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins and assembly admins" do
-      expect(subject.query).to match_array([admin, assembly_admin])
+      expect(subject.query).to contain_exactly(admin, assembly_admin)
     end
 
     context "when asking for organization admin users" do
       subject { described_class.new(nil, organization) }
 
       it "returns all the organization admins and assembly admins" do
-        expect(subject.query).to match_array([admin, assembly_admin, other_assembly_admin])
+        expect(subject.query).to contain_exactly(admin, assembly_admin, other_assembly_admin)
       end
     end
   end

--- a/decidim-assemblies/spec/queries/admin/assembly_members_spec.rb
+++ b/decidim-assemblies/spec/queries/admin/assembly_members_spec.rb
@@ -30,7 +30,7 @@ module Decidim::Assemblies::Admin
           let(:search) { "Argo" }
 
           it "returns all matching assembly members" do
-            expect(subject).to match_array([assembly_members[1], assembly_members[2]])
+            expect(subject).to contain_exactly(assembly_members[1], assembly_members[2])
           end
         end
 
@@ -81,7 +81,7 @@ module Decidim::Assemblies::Admin
         end
 
         it 'returns the "Ceased" assembly members matching the query search' do
-          expect(subject).to match_array([ceased_assembly_members[0], ceased_assembly_members[2]])
+          expect(subject).to contain_exactly(ceased_assembly_members[0], ceased_assembly_members[2])
         end
       end
     end

--- a/decidim-assemblies/spec/queries/parent_assemblies_spec.rb
+++ b/decidim-assemblies/spec/queries/parent_assemblies_spec.rb
@@ -12,7 +12,7 @@ module Decidim::Assemblies
     describe "query" do
       it "only returns parent assemblies" do
         expect(subject.count).to eq(2)
-        expect(subject.pluck(:id)).to match_array([parent_assembly.id, child_assembly.parent.id])
+        expect(subject.pluck(:id)).to contain_exactly(parent_assembly.id, child_assembly.parent.id)
       end
     end
   end

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -104,7 +104,7 @@ describe "Admin manages assemblies", type: :system do
         Decidim::AssembliesType.all.each do |assemblies_type|
           i18n_assemblies_type = assemblies_type.name[I18n.locale.to_s]
 
-          context "filtering collection by assemblies_type: #{i18n_assemblies_type}" do
+          context "when filtering collection by assemblies_type: #{i18n_assemblies_type}" do
             let!(:assembly1) { create(:assembly, organization:, assemblies_type: assemblies_type1) }
             let!(:assembly2) { create(:assembly, organization:, assemblies_type: assemblies_type2) }
 

--- a/decidim-assemblies/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-assemblies/spec/system/admin/valuator_checks_components_spec.rb
@@ -21,7 +21,7 @@ describe "Valuator checks components", type: :system do
   before do
     user.update(admin: false)
 
-    create(:valuation_assignment, proposal: assigned_proposal, valuator_role: valuator_role)
+    create(:valuation_assignment, proposal: assigned_proposal, valuator_role:)
 
     switch_to_host(organization.host)
     login_as user, scope: :user

--- a/decidim-assemblies/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-assemblies/spec/system/homepage_content_blocks_spec.rb
@@ -10,7 +10,7 @@ describe "Homepage assemblies content blocks", type: :system do
   let!(:promoted_external_assembly) { create(:assembly, :promoted) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_assemblies)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies)
     switch_to_host(organization.host)
   end
 

--- a/decidim-blogs/spec/services/decidim/blogs/searchable_blogpost_resource_spec.rb
+++ b/decidim-blogs/spec/services/decidim/blogs/searchable_blogpost_resource_spec.rb
@@ -82,7 +82,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[resource.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [resource, resource2]
+              expect(results[:results]).to contain_exactly(resource, resource2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/budgets_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/budgets_controller.rb
@@ -31,12 +31,12 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :budget, budget: budget
+          enforce_permission_to(:update, :budget, budget:)
           @form = form(BudgetForm).from_model(budget)
         end
 
         def update
-          enforce_permission_to :update, :budget, budget: budget
+          enforce_permission_to(:update, :budget, budget:)
           @form = form(BudgetForm).from_params(params, current_component:)
 
           UpdateBudget.call(@form, budget) do
@@ -53,7 +53,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :budget, budget: budget
+          enforce_permission_to(:delete, :budget, budget:)
 
           DestroyBudget.call(budget, current_user) do
             on(:ok) do

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -42,13 +42,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :project, project: project
+          enforce_permission_to(:update, :project, project:)
           @form = form(ProjectForm).from_model(project)
           @form.attachment = form(AttachmentForm).instance
         end
 
         def update
-          enforce_permission_to :update, :project, project: project
+          enforce_permission_to(:update, :project, project:)
           @form = form(ProjectForm).from_params(params, budget:)
 
           UpdateProject.call(@form, project) do
@@ -65,7 +65,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :project, project: project
+          enforce_permission_to(:destroy, :project, project:)
 
           DestroyProject.call(project, current_user) do
             on(:ok) do

--- a/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       helper_method :budget, :project
 
       def create
-        enforce_permission_to :vote, :project, project: project, budget: budget, workflow: current_workflow
+        enforce_permission_to :vote, :project, project:, budget:, workflow: current_workflow
 
         respond_to do |format|
           AddLineItem.call(persisted_current_order, project, current_user) do

--- a/decidim-budgets/app/controllers/decidim/budgets/orders_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/orders_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       include NeedsCurrentOrder
 
       def checkout
-        enforce_permission_to :vote, :project, order: current_order, budget: budget, workflow: current_workflow
+        enforce_permission_to :vote, :project, order: current_order, budget:, workflow: current_workflow
 
         Checkout.call(current_order) do
           on(:ok) do

--- a/decidim-budgets/spec/controllers/decidim/budgets/admin/projects_controller_spec.rb
+++ b/decidim-budgets/spec/controllers/decidim/budgets/admin/projects_controller_spec.rb
@@ -44,7 +44,7 @@ module Decidim
           it "updates the project" do
             allow(controller).to receive(:budget_projects_path).and_return("/projects")
 
-            patch :update, params: params
+            patch(:update, params:)
 
             expect(flash[:notice]).not_to be_empty
             expect(response).to have_http_status(:found)
@@ -63,7 +63,7 @@ module Decidim
               end
 
               it "displays the editing form with errors" do
-                patch :update, params: params
+                patch(:update, params:)
 
                 expect(flash[:alert]).not_to be_empty
                 expect(response).to have_http_status(:ok)

--- a/decidim-budgets/spec/controllers/decidim/budgets/projects_controller_spec.rb
+++ b/decidim-budgets/spec/controllers/decidim/budgets/projects_controller_spec.rb
@@ -21,8 +21,8 @@ module Decidim
         let(:component) { create(:budgets_component, :with_geocoding_enabled) }
 
         it "sets two different collections" do
-          geocoded_projects = create_list(:project, 10, budget: budget, latitude: 1.1, longitude: 2.2)
-          _non_geocoded_projects = create_list(:project, 2, budget: budget, latitude: nil, longitude: nil)
+          geocoded_projects = create_list(:project, 10, budget:, latitude: 1.1, longitude: 2.2)
+          _non_geocoded_projects = create_list(:project, 2, budget:, latitude: nil, longitude: nil)
 
           get :index, params: { budget_id: budget.id }
           expect(response).to have_http_status(:ok)

--- a/decidim-budgets/spec/lib/decidim/budgets/workflows/all_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/workflows/all_spec.rb
@@ -44,7 +44,7 @@ module Decidim::Budgets
       it_behaves_like "allows voting in every resources"
 
       it "has one discardable order" do
-        expect(workflow.progress).to match_array([order_resource])
+        expect(workflow.progress).to contain_exactly(order_resource)
       end
 
       context "when order has been checked out" do

--- a/decidim-budgets/spec/lib/decidim/budgets/workflows/budgets_workflow_random_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/workflows/budgets_workflow_random_spec.rb
@@ -26,7 +26,7 @@ describe BudgetsWorkflowRandom do
       expect(subject).not_to be_vote_allowed(resource)
     end
 
-    expect(workflow.allowed).to match_array([chosen_resource])
+    expect(workflow.allowed).to contain_exactly(chosen_resource)
   end
 
   it "has an allowed status only for the chosen resource" do
@@ -47,7 +47,7 @@ describe BudgetsWorkflowRandom do
     shared_examples "allows to vote only in the order resource" do
       it "allows to vote in the order resource" do
         expect(subject).to be_vote_allowed(order_resource)
-        expect(workflow.allowed).to match_array([order_resource])
+        expect(workflow.allowed).to contain_exactly(order_resource)
       end
 
       it "does not allow to vote in the other resources" do

--- a/decidim-budgets/spec/lib/decidim/budgets/workflows/one_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/workflows/one_spec.rb
@@ -25,7 +25,7 @@ module Decidim::Budgets
 
       it "allows to vote in the order resource" do
         expect(subject).to be_vote_allowed(order_resource)
-        expect(workflow.allowed).to match_array([order_resource])
+        expect(workflow.allowed).to contain_exactly(order_resource)
       end
 
       it "does not allow to vote in the other resources" do
@@ -64,7 +64,7 @@ module Decidim::Budgets
         end
 
         it "does have a discardable order" do
-          expect(workflow.discardable).to match_array([order_resource])
+          expect(workflow.discardable).to contain_exactly(order_resource)
         end
       end
     end

--- a/decidim-budgets/spec/models/order_spec.rb
+++ b/decidim-budgets/spec/models/order_spec.rb
@@ -20,7 +20,7 @@ shared_examples "an order" do |*options|
 
     it "is unique for each user and component" do
       subject.save
-      new_order = build(:order, user: subject.user, budget: budget)
+      new_order = build(:order, user: subject.user, budget:)
       expect(new_order).to be_invalid
     end
 

--- a/decidim-budgets/spec/services/decidim/budgets/searchable_project_resource_spec.rb
+++ b/decidim-budgets/spec/services/decidim/budgets/searchable_project_resource_spec.rb
@@ -81,7 +81,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[resource.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [resource, resource2]
+              expect(results[:results]).to contain_exactly(resource, resource2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-budgets/spec/shared/workflows_examples.rb
+++ b/decidim-budgets/spec/shared/workflows_examples.rb
@@ -27,7 +27,7 @@ end
 
 shared_examples "highlights a resource" do
   it "highlight only the given resource" do
-    expect(workflow.highlighted).to match_array([highlighted_resource])
+    expect(workflow.highlighted).to contain_exactly(highlighted_resource)
 
     expect(subject).to be_highlighted(highlighted_resource)
 
@@ -83,7 +83,7 @@ shared_examples "has an in-progress order" do
   end
 
   it "has one order in progress" do
-    expect(workflow.progress).to match_array([order_resource])
+    expect(workflow.progress).to contain_exactly(order_resource)
   end
 
   it "does not have any order voted" do
@@ -107,6 +107,6 @@ shared_examples "has a voted order" do
   end
 
   it "has one voted order" do
-    expect(workflow.voted).to match_array([order_resource])
+    expect(workflow.voted).to contain_exactly(order_resource)
   end
 end

--- a/decidim-budgets/spec/system/sorting_projects_spec.rb
+++ b/decidim-budgets/spec/system/sorting_projects_spec.rb
@@ -76,8 +76,8 @@ describe "Sorting projects", type: :system do
 
     context "when ordering by most votes" do
       before do
-        order = build(:order, budget: budget)
-        create(:line_item, order: order, project: project2)
+        order = build(:order, budget:)
+        create(:line_item, order:, project: project2)
         order = Decidim::Budgets::Order.last
         order.checked_out_at = Time.zone.now
         order.save

--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -16,7 +16,7 @@ module Decidim
       helper_method :root_depth, :commentable, :order, :reply?, :reload?, :root_comment
 
       def index
-        enforce_permission_to :read, :comment, commentable: commentable
+        enforce_permission_to(:read, :comment, commentable:)
 
         @comments = SortedComments.for(
           commentable,
@@ -47,7 +47,7 @@ module Decidim
 
       def update
         set_comment
-        enforce_permission_to :update, :comment, comment: comment
+        enforce_permission_to(:update, :comment, comment:)
 
         form = Decidim::Comments::CommentForm.from_params(
           params.merge(commentable: comment.commentable)
@@ -71,7 +71,7 @@ module Decidim
       end
 
       def create
-        enforce_permission_to :create, :comment, commentable: commentable
+        enforce_permission_to(:create, :comment, commentable:)
 
         form = Decidim::Comments::CommentForm.from_params(
           params.merge(commentable:)
@@ -106,7 +106,7 @@ module Decidim
         set_comment
         @commentable = @comment.commentable
 
-        enforce_permission_to :destroy, :comment, comment: comment
+        enforce_permission_to(:destroy, :comment, comment:)
 
         Decidim::Comments::DeleteComment.call(comment, current_user) do
           on(:ok) do

--- a/decidim-comments/app/controllers/decidim/comments/votes_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/votes_controller.rb
@@ -13,7 +13,7 @@ module Decidim
       def create
         raise ActionController::RoutingError, "Not Found" unless comment
 
-        enforce_permission_to :vote, :comment, comment: comment
+        enforce_permission_to(:vote, :comment, comment:)
 
         Decidim::Comments::VoteComment.call(comment, current_user, weight: params[:weight].to_i) do
           on(:ok) do

--- a/decidim-comments/spec/lib/decidim/comments/commentable_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/commentable_spec.rb
@@ -19,7 +19,7 @@ describe Decidim::Comments::Commentable do
 
     describe "comments" do
       it "returns comments in all levels" do
-        expect(subject.comments).to match_array [top_level_comment, second_level_comment]
+        expect(subject.comments).to contain_exactly(top_level_comment, second_level_comment)
       end
     end
   end

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -299,7 +299,7 @@ module Decidim
         context "when passing a non-commentable resource" do
           it "returns the autors of the resources' comments" do
             ids = Decidim::Comments::Comment.user_commentators_ids_in([commentable.component.participatory_space])
-            expect(ids).to match_array([])
+            expect(ids).to be_empty
           end
         end
 

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -306,7 +306,7 @@ module Decidim
         context "when commentors belong to the given resources" do
           it "returns the autors of the resources' comments" do
             ids = Decidim::Comments::Comment.user_commentators_ids_in(Decidim::DummyResources::DummyResource.where(component: commentable.component))
-            expect(ids).to match_array([author.id])
+            expect(ids).to contain_exactly(author.id)
           end
         end
 
@@ -316,7 +316,7 @@ module Decidim
 
           it "does not return them" do
             ids = Decidim::Comments::Comment.user_commentators_ids_in(Decidim::DummyResources::DummyResource.where(component: commentable.component))
-            expect(ids).to match_array([author.id])
+            expect(ids).to contain_exactly(author.id)
           end
         end
       end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_invites_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_invites_controller.rb
@@ -11,7 +11,7 @@ module Decidim
         helper_method :conference
 
         def index
-          enforce_permission_to :read_invites, :conference, conference: conference
+          enforce_permission_to(:read_invites, :conference, conference:)
 
           @query = params[:q]
           @status = params[:status]
@@ -19,13 +19,13 @@ module Decidim
         end
 
         def new
-          enforce_permission_to :invite_attendee, :conference, conference: conference
+          enforce_permission_to(:invite_attendee, :conference, conference:)
 
           @form = form(ConferenceRegistrationInviteForm).instance
         end
 
         def create
-          enforce_permission_to :invite_attendee, :conference, conference: conference
+          enforce_permission_to(:invite_attendee, :conference, conference:)
 
           @form = form(ConferenceRegistrationInviteForm).from_params(params)
 

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_registrations_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_registrations_controller.rb
@@ -12,13 +12,13 @@ module Decidim
         helper_method :conference
 
         def index
-          enforce_permission_to :read_conference_registrations, :conference, conference: conference
+          enforce_permission_to(:read_conference_registrations, :conference, conference:)
 
           @conference_registrations = paginate(Decidim::Conferences::ConferenceRegistration.where(conference:))
         end
 
         def export
-          enforce_permission_to :export_conference_registrations, :conference, conference: conference
+          enforce_permission_to(:export_conference_registrations, :conference, conference:)
 
           ExportConferenceRegistrations.call(conference, params[:format], current_user) do
             on(:ok) do |export_data|
@@ -28,7 +28,7 @@ module Decidim
         end
 
         def confirm
-          enforce_permission_to :confirm, :conference_registration, conference_registration: conference_registration
+          enforce_permission_to(:confirm, :conference_registration, conference_registration:)
 
           ConfirmConferenceRegistration.call(conference_registration, current_user) do
             on(:ok) do

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_registrations_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_registrations_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       before_action :ensure_signed_in
 
       def create
-        enforce_permission_to :join, :conference, conference: conference
+        enforce_permission_to(:join, :conference, conference:)
 
         JoinConference.call(conference, registration_type, current_user) do
           on(:ok) do
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :leave, :conference, conference: conference
+        enforce_permission_to(:leave, :conference, conference:)
 
         LeaveConference.call(conference, registration_type, current_user) do
           on(:ok) do
@@ -39,7 +39,7 @@ module Decidim
       end
 
       def decline_invitation
-        enforce_permission_to :decline_invitation, :conference, conference: conference
+        enforce_permission_to(:decline_invitation, :conference, conference:)
 
         DeclineInvitation.call(conference, current_user) do
           on(:ok) do

--- a/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
@@ -38,7 +38,7 @@ module Decidim
             it "displays list of speakers" do
               get :index, params: { conference_slug: conference.slug }
 
-              expect(controller.helpers.collection).to match_array([speaker1, speaker2])
+              expect(controller.helpers.collection).to contain_exactly(speaker1, speaker2)
             end
           end
 

--- a/decidim-conferences/spec/controllers/conferences_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conferences_controller_spec.rb
@@ -40,7 +40,7 @@ module Decidim
 
       describe "conferences" do
         it "includes only published, with promoted listed first" do
-          expect(controller.helpers.conferences).to match_array([promoted, published])
+          expect(controller.helpers.conferences).to contain_exactly(promoted, published)
         end
       end
 

--- a/decidim-conferences/spec/queries/admin/conference_admins_spec.rb
+++ b/decidim-conferences/spec/queries/admin/conference_admins_spec.rb
@@ -17,14 +17,14 @@ module Decidim::Conferences
     let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins and conference admins" do
-      expect(subject.query).to match_array([admin, conference_admin])
+      expect(subject.query).to contain_exactly(admin, conference_admin)
     end
 
     context "when asking for organization admin users" do
       subject { described_class.new(nil, organization) }
 
       it "returns all the organization admins and conference admins" do
-        expect(subject.query).to match_array([admin, conference_admin, other_conference_admin])
+        expect(subject.query).to contain_exactly(admin, conference_admin, other_conference_admin)
       end
     end
   end

--- a/decidim-conferences/spec/queries/admin/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/queries/admin/conference_speakers_spec.rb
@@ -29,7 +29,7 @@ module Decidim::Conferences::Admin
           let(:search) { "Argo" }
 
           it "returns all matching conference speakers" do
-            expect(subject).to match_array([conference_speakers[1], conference_speakers[2]])
+            expect(subject).to contain_exactly(conference_speakers[1], conference_speakers[2])
           end
         end
 

--- a/decidim-conferences/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-conferences/spec/system/admin/valuator_checks_components_spec.rb
@@ -21,7 +21,7 @@ describe "Valuator checks components", type: :system do
   before do
     user.update(admin: false)
 
-    create(:valuation_assignment, proposal: assigned_proposal, valuator_role: valuator_role)
+    create(:valuation_assignment, proposal: assigned_proposal, valuator_role:)
 
     switch_to_host(organization.host)
     login_as user, scope: :user

--- a/decidim-conferences/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-conferences/spec/system/homepage_content_blocks_spec.rb
@@ -10,7 +10,7 @@ describe "Homepage conferences content blocks", type: :system do
   let!(:promoted_external_conference) { create(:conference, :promoted) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_conferences)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_conferences)
     switch_to_host(organization.host)
   end
 

--- a/decidim-consultations/spec/queries/decidim/consultations/admin/process_admins_spec.rb
+++ b/decidim-consultations/spec/queries/decidim/consultations/admin/process_admins_spec.rb
@@ -13,7 +13,7 @@ module Decidim::Consultations
     let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins" do
-      expect(subject.query).to match_array([admin])
+      expect(subject.query).to contain_exactly(admin)
     end
   end
 end

--- a/decidim-core/app/cells/decidim/tags_cell.rb
+++ b/decidim-core/app/cells/decidim/tags_cell.rb
@@ -53,7 +53,7 @@ module Decidim
     end
 
     def link_to_tag(path, name, title)
-      link_to path, title: title, class: "tag" do
+      link_to path, title:, class: "tag" do
         sr_title = content_tag(
           :span,
           title,

--- a/decidim-core/app/controllers/concerns/decidim/amendments_controller.rb
+++ b/decidim-core/app/controllers/concerns/decidim/amendments_controller.rb
@@ -175,7 +175,7 @@ module Decidim
     end
 
     def withdraw
-      enforce_permission_to :withdraw, :amendment, amendment: amendment, current_component: amendable.component
+      enforce_permission_to :withdraw, :amendment, amendment:, current_component: amendable.component
 
       Decidim::Amendable::Withdraw.call(amendment, current_user) do
         on(:ok) do |withdrawn_emendation|

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -8,12 +8,12 @@ module Decidim
     helper Decidim::PasswordsHelper
 
     def show
-      enforce_permission_to :show, :user, current_user: current_user
+      enforce_permission_to(:show, :user, current_user:)
       @account = form(AccountForm).from_model(current_user)
     end
 
     def update
-      enforce_permission_to :update, :user, current_user: current_user
+      enforce_permission_to(:update, :user, current_user:)
       @account = form(AccountForm).from_params(account_params)
 
       UpdateAccount.call(current_user, @account) do
@@ -36,12 +36,12 @@ module Decidim
     end
 
     def delete
-      enforce_permission_to :delete, :user, current_user: current_user
+      enforce_permission_to(:delete, :user, current_user:)
       @form = form(DeleteAccountForm).from_model(current_user)
     end
 
     def destroy
-      enforce_permission_to :delete, :user, current_user: current_user
+      enforce_permission_to(:delete, :user, current_user:)
       @form = form(DeleteAccountForm).from_params(params)
 
       DestroyAccount.call(current_user, @form) do
@@ -59,7 +59,7 @@ module Decidim
     end
 
     def resend_confirmation_instructions
-      enforce_permission_to :update, :user, current_user: current_user
+      enforce_permission_to(:update, :user, current_user:)
 
       ResendConfirmationInstructions.call(current_user) do
         on(:ok) do
@@ -79,7 +79,7 @@ module Decidim
     end
 
     def cancel_email_change
-      enforce_permission_to :update, :user, current_user: current_user
+      enforce_permission_to(:update, :user, current_user:)
 
       if current_user.unconfirmed_email
         current_user.update(unconfirmed_email: nil)

--- a/decidim-core/app/controllers/decidim/download_your_data_controller.rb
+++ b/decidim-core/app/controllers/decidim/download_your_data_controller.rb
@@ -8,13 +8,13 @@ module Decidim
     include Decidim::UserProfile
 
     def show
-      enforce_permission_to :show, :user, current_user: current_user
+      enforce_permission_to(:show, :user, current_user:)
 
       @account = form(AccountForm).from_model(current_user)
     end
 
     def export
-      enforce_permission_to :export, :user, current_user: current_user
+      enforce_permission_to(:export, :user, current_user:)
 
       DownloadYourDataExportJob.perform_later(current_user)
 
@@ -23,7 +23,7 @@ module Decidim
     end
 
     def download_file
-      enforce_permission_to :download, :user, current_user: current_user
+      enforce_permission_to(:download, :user, current_user:)
 
       if current_user.download_your_data_file.attached?
         redirect_to Rails.application.routes.url_helpers.rails_blob_url(current_user.download_your_data_file.blob, only_path: true)

--- a/decidim-core/app/controllers/decidim/endorsements_controller.rb
+++ b/decidim-core/app/controllers/decidim/endorsements_controller.rb
@@ -13,7 +13,7 @@ module Decidim
     before_action :authenticate_user!
 
     def create
-      enforce_permission_to :create, :endorsement, resource: resource
+      enforce_permission_to(:create, :endorsement, resource:)
       user_group_id = params[:user_group_id]
 
       EndorseResource.call(resource, current_user, user_group_id) do
@@ -29,7 +29,7 @@ module Decidim
     end
 
     def destroy
-      enforce_permission_to :withdraw, :endorsement, resource: resource
+      enforce_permission_to(:withdraw, :endorsement, resource:)
       user_group_id = params[:user_group_id]
       user_group = user_groups.find(user_group_id) if user_group_id
 
@@ -42,7 +42,7 @@ module Decidim
     end
 
     def identities
-      enforce_permission_to :create, :endorsement, resource: resource
+      enforce_permission_to(:create, :endorsement, resource:)
 
       @user_verified_groups = Decidim::UserGroups::ManageableUserGroups.for(current_user).verified
       render :identities, layout: false

--- a/decidim-core/app/controllers/decidim/group_admins_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_admins_controller.rb
@@ -15,7 +15,7 @@ module Decidim
     end
 
     def demote
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
 
       DemoteMembership.call(membership, user_group) do
         on(:ok) do

--- a/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_email_confirmations_controller.rb
@@ -11,7 +11,7 @@ module Decidim
     helper_method :user_group
 
     def create
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
       if user_group.email.blank?
         flash.keep[:alert] = t("decidim.profiles.user.fill_in_email_to_confirm_it")
         redirect_to(edit_group_path(user_group.nickname)) && return

--- a/decidim-core/app/controllers/decidim/group_invites_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_invites_controller.rb
@@ -11,12 +11,12 @@ module Decidim
     helper_method :user_group
 
     def index
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
       @form = form(InviteUserToGroupForm).instance
     end
 
     def create
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
       @form = form(InviteUserToGroupForm).from_params(params)
 
       InviteUserToGroup.call(@form, user_group) do

--- a/decidim-core/app/controllers/decidim/group_members_controller.rb
+++ b/decidim-core/app/controllers/decidim/group_members_controller.rb
@@ -16,7 +16,7 @@ module Decidim
 
     # Removes a user from a user group
     def destroy
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
 
       RemoveUserFromGroup.call(membership, user_group) do
         on(:ok) do
@@ -33,7 +33,7 @@ module Decidim
     end
 
     def promote
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
 
       PromoteMembership.call(membership, user_group) do
         on(:ok) do

--- a/decidim-core/app/controllers/decidim/groups_controller.rb
+++ b/decidim-core/app/controllers/decidim/groups_controller.rb
@@ -10,12 +10,12 @@ module Decidim
     before_action :ensure_user_group_not_blocked
 
     def new
-      enforce_permission_to :create, :user_group, current_user: current_user
+      enforce_permission_to(:create, :user_group, current_user:)
       @form = form(UserGroupForm).instance
     end
 
     def create
-      enforce_permission_to :create, :user_group, current_user: current_user
+      enforce_permission_to(:create, :user_group, current_user:)
       @form = form(UserGroupForm).from_params(params)
 
       CreateUserGroup.call(@form) do
@@ -33,12 +33,12 @@ module Decidim
     end
 
     def edit
-      enforce_permission_to :manage, :user_group, current_user: current_user, user_group: user_group
+      enforce_permission_to(:manage, :user_group, current_user:, user_group:)
       @form = form(UserGroupForm).from_model(user_group)
     end
 
     def update
-      enforce_permission_to :manage, :user_group, current_user: current_user, user_group: user_group
+      enforce_permission_to(:manage, :user_group, current_user:, user_group:)
       @form = form(UserGroupForm).from_params(user_group_params)
 
       UpdateUserGroup.call(@form, user_group) do

--- a/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
@@ -71,7 +71,7 @@ module Decidim
       end
 
       def show
-        enforce_permission_to :read, :conversation, conversation: conversation
+        enforce_permission_to(:read, :conversation, conversation:)
 
         @conversation.mark_as_read(current_user)
 
@@ -79,7 +79,7 @@ module Decidim
       end
 
       def update
-        enforce_permission_to :update, :conversation, conversation: conversation
+        enforce_permission_to(:update, :conversation, conversation:)
 
         @form = form(MessageForm).from_params(params, sender: current_user)
 

--- a/decidim-core/app/controllers/decidim/newsletters_opt_in_controller.rb
+++ b/decidim-core/app/controllers/decidim/newsletters_opt_in_controller.rb
@@ -8,7 +8,7 @@ module Decidim
     before_action :check_current_user_with_token
 
     def update
-      enforce_permission_to :update, :user, current_user: current_user
+      enforce_permission_to(:update, :user, current_user:)
 
       current_user.newsletter_opt_in_validate
       if current_user.save

--- a/decidim-core/app/controllers/decidim/notifications_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_controller.rb
@@ -9,7 +9,7 @@ module Decidim
 
     def destroy
       notification = notifications.find(params[:id])
-      enforce_permission_to :destroy, :notification, notification: notification
+      enforce_permission_to(:destroy, :notification, notification:)
       notification.destroy
     end
 

--- a/decidim-core/app/controllers/decidim/notifications_settings_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_settings_controller.rb
@@ -6,12 +6,12 @@ module Decidim
     include Decidim::UserProfile
 
     def show
-      enforce_permission_to :read, :user, current_user: current_user
+      enforce_permission_to(:read, :user, current_user:)
       @notifications_settings = form(NotificationsSettingsForm).from_model(current_user)
     end
 
     def update
-      enforce_permission_to :update, :user, current_user: current_user
+      enforce_permission_to(:update, :user, current_user:)
       @notifications_settings = form(NotificationsSettingsForm).from_params(params)
 
       UpdateNotificationsSettings.call(current_user, @notifications_settings) do

--- a/decidim-core/app/controllers/decidim/user_conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_conversations_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
     # shows a conversation thread and presents a form to reply in ajax
     def show
-      enforce_permission_to :show, :conversation, interlocutor: user, conversation: conversation
+      enforce_permission_to(:show, :conversation, interlocutor: user, conversation:)
 
       conversation.mark_as_read(current_user)
     end
@@ -34,7 +34,7 @@ module Decidim
     # receive replies in ajax, messages are returned through the view update.js.erb and printed
     # over the form instead of using flash messages
     def update
-      enforce_permission_to :update, :conversation, interlocutor: user, conversation: conversation
+      enforce_permission_to(:update, :conversation, interlocutor: user, conversation:)
 
       @form = form(Messaging::MessageForm).from_params(params, sender: user)
 

--- a/decidim-core/app/controllers/decidim/user_group_join_requests_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_group_join_requests_controller.rb
@@ -26,7 +26,7 @@ module Decidim
     end
 
     def update
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
 
       AcceptUserGroupJoinRequest.call(membership) do
         on(:ok) do
@@ -43,7 +43,7 @@ module Decidim
     end
 
     def destroy
-      enforce_permission_to :manage, :user_group, user_group: user_group
+      enforce_permission_to(:manage, :user_group, user_group:)
 
       RejectUserGroupJoinRequest.call(membership) do
         on(:ok) do

--- a/decidim-core/app/controllers/decidim/user_interests_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_interests_controller.rb
@@ -6,12 +6,12 @@ module Decidim
     include Decidim::UserProfile
 
     def show
-      enforce_permission_to :read, :user, current_user: current_user
+      enforce_permission_to(:read, :user, current_user:)
       @user_interests = form(UserInterestsForm).from_model(current_user)
     end
 
     def update
-      enforce_permission_to :update, :user, current_user: current_user
+      enforce_permission_to(:update, :user, current_user:)
       @user_interests = form(UserInterestsForm).from_params(params)
 
       UpdateUserInterests.call(current_user, @user_interests) do

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -48,7 +48,7 @@ module Decidim
       def link_to_current_or_new_conversation_with(user, title = t("decidim.contact"))
         conversation_path = current_or_new_conversation_path_with(user)
         if conversation_path
-          link_to conversation_path, title: title do
+          link_to(conversation_path, title:) do
             icon "envelope-closed", aria_label: title, class: "icon--small"
           end
         else

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -128,9 +128,7 @@ module Decidim
         # Include it in ActiveRecord base in order to apply it to all models
         # that may be using the `geocoded_by` or `reverse_geocoded_by` class
         # methods injected by the Geocoder gem.
-        ActiveSupport.on_load :active_record do
-          ActiveRecord::Base.include Decidim::Geocodable
-        end
+        ActiveSupport.on_load(:active_record) { include Decidim::Geocodable }
       end
 
       initializer "decidim_core.maps" do

--- a/decidim-core/spec/commands/decidim/search_spec.rb
+++ b/decidim-core/spec/commands/decidim/search_spec.rb
@@ -377,7 +377,7 @@ describe Decidim::Search do
             on(:ok) do |results_by_type|
               results = results_by_type["Decidim::DummyResources::DummyResource"]
               expect(results[:count]).to eq 3
-              expect(results[:results]).to match_array [active.resource, past.resource, future.resource]
+              expect(results[:results]).to contain_exactly(active.resource, past.resource, future.resource)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-core/spec/content_parsers/decidim/user_group_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/user_group_parser_spec.rb
@@ -46,7 +46,7 @@ module Decidim
 
       it "returns the correct metadata" do
         expect(parser.metadata).to be_a(Decidim::ContentParsers::UserGroupParser::Metadata)
-        expect(parser.metadata.groups).to match_array([user_group, user_group2])
+        expect(parser.metadata.groups).to contain_exactly(user_group, user_group2)
       end
     end
 
@@ -73,7 +73,7 @@ module Decidim
 
       it "returns the correct metadata" do
         expect(parser.metadata).to be_a(Decidim::ContentParsers::UserGroupParser::Metadata)
-        expect(parser.metadata.groups).to match_array([user_group, user_group2])
+        expect(parser.metadata.groups).to contain_exactly(user_group, user_group2)
       end
 
       def html_mention(mentionable)

--- a/decidim-core/spec/content_parsers/decidim/user_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/user_parser_spec.rb
@@ -46,7 +46,7 @@ module Decidim
 
       it "returns the correct metadata" do
         expect(parser.metadata).to be_a(Decidim::ContentParsers::UserParser::Metadata)
-        expect(parser.metadata.users).to match_array([user, user2])
+        expect(parser.metadata.users).to contain_exactly(user, user2)
       end
     end
 
@@ -86,7 +86,7 @@ module Decidim
 
       it "returns the correct metadata" do
         expect(parser.metadata).to be_a(Decidim::ContentParsers::UserParser::Metadata)
-        expect(parser.metadata.users).to match_array([user, user2])
+        expect(parser.metadata.users).to contain_exactly(user, user2)
       end
 
       def html_mention(mentionable)

--- a/decidim-core/spec/controllers/amendments_controller_spec.rb
+++ b/decidim-core/spec/controllers/amendments_controller_spec.rb
@@ -60,14 +60,14 @@ module Decidim
 
             it "renders the view: compare_draft" do
               allow(Decidim::SimilarEmendations).to receive(:for).and_return([similar_emendation])
-              get :compare_draft, params: params
+              get(:compare_draft, params:)
               expect(subject).to render_template(:compare_draft)
             end
           end
 
           context "without similar emendations" do
             it "redirects to edit_draft" do
-              get :compare_draft, params: params
+              get(:compare_draft, params:)
               expect(response).to redirect_to edit_draft_amend_path(amendment)
             end
           end
@@ -105,7 +105,7 @@ module Decidim
           let(:amendment_state) { "draft" }
 
           it "renders the view: edit_draft" do
-            get :edit_draft, params: params
+            get(:edit_draft, params:)
             expect(subject).to render_template(:edit_draft)
           end
         end
@@ -192,7 +192,7 @@ module Decidim
           let(:amendment_state) { "draft" }
 
           it "destroys the draft" do
-            delete :destroy_draft, params: params
+            delete(:destroy_draft, params:)
             expect(flash[:notice]).to eq("Amendment draft was successfully deleted.")
           end
         end
@@ -229,7 +229,7 @@ module Decidim
           let(:amendment_state) { "draft" }
 
           it "renders the view: preview_draft" do
-            get :preview_draft, params: params
+            get(:preview_draft, params:)
             expect(subject).to render_template(:preview_draft)
           end
         end

--- a/decidim-core/spec/controllers/decidim/devise/invitations_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/devise/invitations_controller_spec.rb
@@ -35,7 +35,7 @@ module Decidim::Devise
 
       it "responds to the edit path" do
         get :edit, params: { invitation_token: user.raw_invitation_token }
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
 
       it "redirects to the provided path" do

--- a/decidim-core/spec/controllers/decidim/devise/invitations_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/devise/invitations_controller_spec.rb
@@ -35,7 +35,7 @@ module Decidim::Devise
 
       it "responds to the edit path" do
         get :edit, params: { invitation_token: user.raw_invitation_token }
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(200)
       end
 
       it "redirects to the provided path" do

--- a/decidim-core/spec/controllers/decidim/endorsements_controller_as_user_spec.rb
+++ b/decidim-core/spec/controllers/decidim/endorsements_controller_as_user_spec.rb
@@ -21,7 +21,7 @@ module Decidim
 
         context "when requesting user identities without belonging to any user_group" do
           it "only returns the user identity endorse button" do
-            get :identities, params: params
+            get(:identities, params:)
 
             expect(response).to have_http_status(:ok)
             expect(assigns[:user_verified_groups]).to be_empty
@@ -32,7 +32,7 @@ module Decidim
         context "when requesting user identities while belonging to UNverified user_groups" do
           it "only returns the user identity endorse button" do
             create_list(:user_group, 2, users: [user], organization: user.organization)
-            get :identities, params: params
+            get(:identities, params:)
 
             expect(response).to have_http_status(:ok)
             expect(assigns[:user_verified_groups]).to be_empty
@@ -43,7 +43,7 @@ module Decidim
         context "when requesting user identities while belonging to verified user_groups" do
           it "returns the user's and user_groups's identities for the endorse button" do
             create_list(:user_group, 2, :verified, users: [user], organization: user.organization)
-            get :identities, params: params
+            get(:identities, params:)
 
             expect(response).to have_http_status(:ok)
             expect(assigns[:user_verified_groups]).to eq user.user_groups
@@ -66,7 +66,7 @@ module Decidim
 
         context "when requesting user identities" do
           it "raises exception" do
-            get :identities, params: params
+            get(:identities, params:)
             expect(response).to have_http_status(:found)
           end
         end
@@ -88,7 +88,7 @@ module Decidim
 
         context "when requesting user identities" do
           it "does not allow it" do
-            get :identities, params: params
+            get(:identities, params:)
             expect(response).to have_http_status(:found)
           end
         end

--- a/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
@@ -33,7 +33,7 @@ module Decidim
         it "returns seconds until timeout" do
           expect(controller).not_to receive(:store_current_location)
 
-          get :seconds_until_timeout, format: :json, params: params
+          get(:seconds_until_timeout, format: :json, params:)
 
           expect(response.status).to eq(200)
           expect(parsed_response["seconds_remaining"])

--- a/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
@@ -35,7 +35,7 @@ module Decidim
 
           get(:seconds_until_timeout, format: :json, params:)
 
-          expect(response).to have_http_status(200)
+          expect(response).to have_http_status(:ok)
           expect(parsed_response["seconds_remaining"])
             .to be_between(timeout_time.to_i - time_since_last_request.to_i - max_delay, timeout_time.to_i - time_since_last_request.to_i)
         end

--- a/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
@@ -35,7 +35,7 @@ module Decidim
 
           get(:seconds_until_timeout, format: :json, params:)
 
-          expect(response.status).to eq(200)
+          expect(response).to have_http_status(200)
           expect(parsed_response["seconds_remaining"])
             .to be_between(timeout_time.to_i - time_since_last_request.to_i - max_delay, timeout_time.to_i - time_since_last_request.to_i)
         end

--- a/decidim-core/spec/controllers/decidim/upload_validations_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/upload_validations_controller_spec.rb
@@ -26,7 +26,7 @@ module Decidim
       it "validates" do
         post(:create, params:)
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
         expect(parsed_response).to eq([])
       end
     end

--- a/decidim-core/spec/controllers/decidim/upload_validations_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/upload_validations_controller_spec.rb
@@ -24,7 +24,7 @@ module Decidim
 
     describe "#create" do
       it "validates" do
-        post :create, params: params
+        post(:create, params:)
 
         expect(response.status).to eq(200)
         expect(parsed_response).to eq([])

--- a/decidim-core/spec/controllers/decidim/upload_validations_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/upload_validations_controller_spec.rb
@@ -26,7 +26,7 @@ module Decidim
       it "validates" do
         post(:create, params:)
 
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(200)
         expect(parsed_response).to eq([])
       end
     end

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -31,7 +31,7 @@ module Decidim
       end
 
       def send_form_and_expect_rendering_the_new_template_again
-        post :create, params: params
+        post(:create, params:)
         expect(controller).to render_template "new"
       end
 
@@ -45,7 +45,7 @@ module Decidim
         end
 
         it "does not ask the user to confirm the email" do
-          post :create, params: params
+          post(:create, params:)
           expect(controller.flash.notice).not_to have_content("confirmation")
         end
       end
@@ -58,7 +58,7 @@ module Decidim
         end
 
         it "adds the flash message" do
-          post :create, params: params
+          post(:create, params:)
           expect(controller.flash.now[:alert]).to have_content("Your email cannot be blank")
         end
 
@@ -79,7 +79,7 @@ module Decidim
           end
 
           it "adds the flash message" do
-            post :create, params: params
+            post(:create, params:)
             expect(controller.flash.now[:alert]).to have_content(
               [
                 "Your name cannot be blank",

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -103,7 +103,7 @@ module Decidim
             let(:password) { "decidim123" }
 
             it "does not update password_updated_at" do
-              post :create, params: params
+              post(:create, params:)
 
               expect(user.reload.password_updated_at).not_to be_nil
             end
@@ -115,7 +115,7 @@ module Decidim
             let(:user) { create(:user, :confirmed, :admin) }
 
             it "does not change password_updated_at" do
-              post :create, params: params
+              post(:create, params:)
 
               expect(user.reload.password_updated_at).not_to be_nil
             end
@@ -132,7 +132,7 @@ module Decidim
             end
 
             it "sets password_updated_at to nil" do
-              post :create, params: params
+              post(:create, params:)
 
               expect(user.reload.password_updated_at).to be_nil
             end

--- a/decidim-core/spec/controllers/short_links_controller_spec.rb
+++ b/decidim-core/spec/controllers/short_links_controller_spec.rb
@@ -27,7 +27,7 @@ module Decidim
       let(:params) { { id: short_link.identifier } }
 
       it "redirects to the full URL of the short link" do
-        get :show, params: params
+        get(:show, params:)
 
         expect(response).to redirect_to(short_link.target_url)
       end

--- a/decidim-core/spec/lib/content_block_manifest_spec.rb
+++ b/decidim-core/spec/lib/content_block_manifest_spec.rb
@@ -88,7 +88,7 @@ module Decidim
         expect(subject.cell).to eq cell
         expect(subject.name).to eq name
         image_names = subject.images.pluck(:name)
-        expect(image_names).to match_array [:image1, :image2]
+        expect(image_names).to contain_exactly(:image1, :image2)
       end
     end
 

--- a/decidim-core/spec/lib/friendly_dates_spec.rb
+++ b/decidim-core/spec/lib/friendly_dates_spec.rb
@@ -21,11 +21,7 @@ module Decidim
     let(:enhanced_instance) { enhanced_class.new(date) }
 
     describe "#friendly_created_at" do
-      around do |example|
-        travel_to Time.zone.local(1945, 2, 6) do
-          example.run
-        end
-      end
+      before { travel_to Time.zone.local(1945, 2, 6) }
 
       describe "when in the same day" do
         let(:date) { Time.current.beginning_of_day + 1.minute }

--- a/decidim-core/spec/lib/webpacker/compiler_spec.rb
+++ b/decidim-core/spec/lib/webpacker/compiler_spec.rb
@@ -18,7 +18,7 @@ module Webpacker
         threads.each(&:join)
 
         expect(results.length).to eq(10)
-        expect(results.uniq).to match_array([true])
+        expect(results.uniq).to contain_exactly(true)
       end
     end
   end

--- a/decidim-core/spec/models/decidim/area_type_spec.rb
+++ b/decidim-core/spec/models/decidim/area_type_spec.rb
@@ -13,7 +13,7 @@ module Decidim
 
       let(:areas) { create_list(:area, 2, area_type:) }
 
-      it { is_expected.to contain_exactly(*areas) }
+      it { is_expected.to match_array(areas) }
     end
 
     context "without name" do

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -40,7 +40,7 @@ module Decidim
 
         it "shows the correct error" do
           expect(subject.valid?).to be(false)
-          expect(subject.errors[:file]).to match_array(["File cannot be processed"])
+          expect(subject.errors[:file]).to contain_exactly("File cannot be processed")
         end
       end
     end

--- a/decidim-core/spec/models/decidim/follow_spec.rb
+++ b/decidim-core/spec/models/decidim/follow_spec.rb
@@ -39,7 +39,7 @@ describe Decidim::Follow do
     context "when following a resource" do
       it "increases the following count" do
         expect do
-          create(:follow, user: user)
+          create(:follow, user:)
           user.reload
         end.to change(user, :following_count).by(1)
       end
@@ -48,7 +48,7 @@ describe Decidim::Follow do
     context "when following a user" do
       it "increases the following count" do
         expect do
-          create(:follow, user: user, followable: another_user)
+          create(:follow, user:, followable: another_user)
           user.reload
         end.to change(user, :following_count).by(1)
       end
@@ -57,7 +57,7 @@ describe Decidim::Follow do
     context "when being followed" do
       it "increases the followers count" do
         expect do
-          create(:follow, user: user, followable: another_user)
+          create(:follow, user:, followable: another_user)
           user.reload
         end.to change(another_user, :followers_count).by(1)
       end
@@ -70,7 +70,7 @@ describe Decidim::Follow do
 
     context "when unfollowing a resource" do
       it "decreases the following count" do
-        follow = create(:follow, user: user)
+        follow = create(:follow, user:)
         expect do
           follow.destroy!
           user.reload
@@ -80,7 +80,7 @@ describe Decidim::Follow do
 
     context "when unfollowing a user" do
       it "decreases the following count" do
-        follow = create(:follow, user: user, followable: another_user)
+        follow = create(:follow, user:, followable: another_user)
         expect do
           follow.destroy!
           user.reload
@@ -90,7 +90,7 @@ describe Decidim::Follow do
 
     context "when not being followed anymore" do
       it "decreases the followers count" do
-        follow = create(:follow, user: user, followable: another_user)
+        follow = create(:follow, user:, followable: another_user)
         expect do
           follow.destroy!
           user.reload

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -39,7 +39,7 @@ module Decidim
 
       let(:scopes) { create_list(:scope, 2, organization:) }
 
-      it { is_expected.to contain_exactly(*scopes) }
+      it { is_expected.to match_array(scopes) }
     end
 
     describe "has an association for scope types" do
@@ -47,7 +47,7 @@ module Decidim
 
       let(:scope_types) { create_list(:scope_type, 2, organization:) }
 
-      it { is_expected.to contain_exactly(*scope_types) }
+      it { is_expected.to match_array(scope_types) }
     end
 
     describe "validations" do

--- a/decidim-core/spec/models/decidim/scope_spec.rb
+++ b/decidim-core/spec/models/decidim/scope_spec.rb
@@ -16,7 +16,7 @@ module Decidim
 
       let(:scopes) { create_list(:scope, 2, parent: scope) }
 
-      it { is_expected.to contain_exactly(*scopes) }
+      it { is_expected.to match_array(scopes) }
     end
 
     context "with two scopes with the same code and organization" do

--- a/decidim-core/spec/models/decidim/scope_type_spec.rb
+++ b/decidim-core/spec/models/decidim/scope_type_spec.rb
@@ -13,7 +13,7 @@ module Decidim
 
       let(:scopes) { create_list(:scope, 2, scope_type:) }
 
-      it { is_expected.to contain_exactly(*scopes) }
+      it { is_expected.to match_array(scopes) }
     end
 
     context "without name" do

--- a/decidim-core/spec/models/decidim/user_base_entity_spec.rb
+++ b/decidim-core/spec/models/decidim/user_base_entity_spec.rb
@@ -21,7 +21,7 @@ module Decidim
 
     describe "public followings" do
       it "return all the things followed unless the blocked users" do
-        expect(subject.public_followings).to match_array([public_resource, user_followed])
+        expect(subject.public_followings).to contain_exactly(public_resource, user_followed)
       end
     end
   end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_memberships_spec.rb
@@ -17,6 +17,6 @@ describe Decidim::UserGroups::AcceptedMemberships do
   let!(:deleted_member) { create(:user_group_membership, user_group:, role: :member, user: deleted_user) }
 
   it "finds the active memberships for the user group" do
-    expect(subject).to match_array([creator, admin, member])
+    expect(subject).to contain_exactly(creator, admin, member)
   end
 end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_user_groups_spec.rb
@@ -14,9 +14,9 @@ describe Decidim::UserGroups::AcceptedUserGroups do
   let!(:requested_user_group) { create(:user_group, organization:, users: []) }
 
   before do
-    create(:user_group_membership, user: user, user_group: creator_user_group, role: :creator)
-    create(:user_group_membership, user: user, user_group: admin_user_group, role: :admin)
-    create(:user_group_membership, user: user, user_group: member_user_group, role: :member)
+    create(:user_group_membership, user:, user_group: creator_user_group, role: :creator)
+    create(:user_group_membership, user:, user_group: admin_user_group, role: :admin)
+    create(:user_group_membership, user:, user_group: member_user_group, role: :member)
     create(:user_group_membership, user:, user_group: requested_user_group, role: :requested)
   end
 

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_user_groups_spec.rb
@@ -21,6 +21,6 @@ describe Decidim::UserGroups::AcceptedUserGroups do
   end
 
   it "finds the user groups where the user has an accepted membership" do
-    expect(subject).to match_array([creator_user_group, admin_user_group, member_user_group])
+    expect(subject).to contain_exactly(creator_user_group, admin_user_group, member_user_group)
   end
 end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_users_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_users_spec.rb
@@ -22,6 +22,6 @@ describe Decidim::UserGroups::AcceptedUsers do
   end
 
   it "finds the active members for the user group" do
-    expect(subject).to match_array([creator_user, admin_user, member_user])
+    expect(subject).to contain_exactly(creator_user, admin_user, member_user)
   end
 end

--- a/decidim-core/spec/queries/decidim/user_groups/accepted_users_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/accepted_users_spec.rb
@@ -15,9 +15,9 @@ describe Decidim::UserGroups::AcceptedUsers do
   let!(:user_group) { create(:user_group, organization:, users: []) }
 
   before do
-    create(:user_group_membership, user: creator_user, user_group: user_group, role: :creator)
-    create(:user_group_membership, user: admin_user, user_group: user_group, role: :admin)
-    create(:user_group_membership, user: member_user, user_group: user_group, role: :member)
+    create(:user_group_membership, user: creator_user, user_group:, role: :creator)
+    create(:user_group_membership, user: admin_user, user_group:, role: :admin)
+    create(:user_group_membership, user: member_user, user_group:, role: :member)
     create(:user_group_membership, user: requested_user, user_group:, role: :requested)
   end
 

--- a/decidim-core/spec/queries/decidim/user_groups/admin_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/admin_memberships_spec.rb
@@ -17,6 +17,6 @@ describe Decidim::UserGroups::AdminMemberships do
   let!(:deleted_member) { create(:user_group_membership, user_group:, role: :member, user: deleted_user) }
 
   it "finds the admin memberships for the user group" do
-    expect(subject).to match_array([admin])
+    expect(subject).to contain_exactly(admin)
   end
 end

--- a/decidim-core/spec/queries/decidim/user_groups/invited_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/invited_memberships_spec.rb
@@ -15,6 +15,6 @@ describe Decidim::UserGroups::InvitedMemberships do
   let(:invited_membership) { create(:user_group_membership, user:, role: :invited) }
 
   it "finds the user groups where the user has a pending membership" do
-    expect(subject).to match_array([invited_membership])
+    expect(subject).to contain_exactly(invited_membership)
   end
 end

--- a/decidim-core/spec/queries/decidim/user_groups/manageable_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/manageable_user_groups_spec.rb
@@ -21,6 +21,6 @@ describe Decidim::UserGroups::ManageableUserGroups do
   end
 
   it "finds the user groups the user can manage" do
-    expect(subject).to match_array([creator_user_group, admin_user_group])
+    expect(subject).to contain_exactly(creator_user_group, admin_user_group)
   end
 end

--- a/decidim-core/spec/queries/decidim/user_groups/manageable_user_groups_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/manageable_user_groups_spec.rb
@@ -14,9 +14,9 @@ describe Decidim::UserGroups::ManageableUserGroups do
   let!(:requested_user_group) { create(:user_group, organization:, users: []) }
 
   before do
-    create(:user_group_membership, user: user, user_group: creator_user_group, role: :creator)
-    create(:user_group_membership, user: user, user_group: admin_user_group, role: :admin)
-    create(:user_group_membership, user: user, user_group: member_user_group, role: :member)
+    create(:user_group_membership, user:, user_group: creator_user_group, role: :creator)
+    create(:user_group_membership, user:, user_group: admin_user_group, role: :admin)
+    create(:user_group_membership, user:, user_group: member_user_group, role: :member)
     create(:user_group_membership, user:, user_group: requested_user_group, role: :requested)
   end
 

--- a/decidim-core/spec/queries/decidim/user_groups/member_memberships_spec.rb
+++ b/decidim-core/spec/queries/decidim/user_groups/member_memberships_spec.rb
@@ -17,6 +17,6 @@ describe Decidim::UserGroups::MemberMemberships do
   let!(:requested) { create(:user_group_membership, user_group:, role: :requested) }
 
   it "finds the member memberships for the user group" do
-    expect(subject).to match_array([member])
+    expect(subject).to contain_exactly(member)
   end
 end

--- a/decidim-core/spec/services/decidim/log/diff_changeset_calculator_spec.rb
+++ b/decidim-core/spec/services/decidim/log/diff_changeset_calculator_spec.rb
@@ -29,11 +29,11 @@ describe Decidim::Log::DiffChangesetCalculator do
 
   describe "#changeset" do
     it "only keeps the fields in fields mapping" do
-      expect(attribute_names).to match_array([:updated_at, :title])
+      expect(attribute_names).to contain_exactly(:updated_at, :title)
     end
 
     it "generates the correct structure for the fields" do
-      expect(title_attribute.keys).to match_array([:attribute_name, :label, :previous_value, :new_value, :type])
+      expect(title_attribute.keys).to contain_exactly(:attribute_name, :label, :previous_value, :new_value, :type)
       expect(title_attribute[:attribute_name]).to eq :title
       expect(title_attribute[:previous_value]).to eq "Old title"
       expect(title_attribute[:new_value]).to eq "New title"
@@ -209,7 +209,7 @@ describe Decidim::Log::DiffChangesetCalculator do
       let(:fields_mapping) { nil }
 
       it "renders nothing" do
-        expect(attribute_names).to match_array([:start_date, :title, :updated_at])
+        expect(attribute_names).to contain_exactly(:start_date, :title, :updated_at)
       end
     end
   end

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -28,11 +28,11 @@ describe "Homepage", type: :system do
     end
 
     before do
-      create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :hero)
-      create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :sub_hero)
-      create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_content_banner)
-      create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :how_to_participate)
-      create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :footer_sub_hero)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :hero)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :sub_hero)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_content_banner)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :how_to_participate)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :footer_sub_hero)
 
       switch_to_host(organization.host)
     end
@@ -300,7 +300,7 @@ describe "Homepage", type: :system do
           let(:organization) { create(:organization) }
 
           before do
-            create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :stats)
+            create(:content_block, organization:, scope_name: :homepage, manifest_name: :stats)
             visit current_path
           end
 
@@ -344,7 +344,7 @@ describe "Homepage", type: :system do
           context "and have metric records" do
             before do
               metrics
-              create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :metrics)
+              create(:content_block, organization:, scope_name: :homepage, manifest_name: :metrics)
               visit current_path
             end
 
@@ -363,7 +363,7 @@ describe "Homepage", type: :system do
 
           context "and does not have metric records" do
             before do
-              create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :metrics)
+              create(:content_block, organization:, scope_name: :homepage, manifest_name: :metrics)
               visit current_path
             end
 

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -35,7 +35,7 @@ describe "Last activity", type: :system do
       %w(Decidim::DummyResources::DummyResource)
     )
 
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :last_activity)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :last_activity)
     switch_to_host organization.host
   end
 

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -26,7 +26,7 @@ describe "User group leaving", type: :system do
         let(:another_admin) { create(:user, :confirmed, organization: user.organization) }
 
         before do
-          create(:user_group_membership, user: another_admin, user_group: user_group, role: :admin)
+          create(:user_group_membership, user: another_admin, user_group:, role: :admin)
           visit decidim.profile_path(user_group.nickname)
         end
 
@@ -43,7 +43,7 @@ describe "User group leaving", type: :system do
       let(:another_user) { create(:user, :confirmed, organization: user.organization) }
 
       before do
-        create(:user_group_membership, user: user, user_group: user_group, role: :admin)
+        create(:user_group_membership, user:, user_group:, role: :admin)
         create(:user_group_membership, user: another_user, user_group:, role: :admin)
       end
 

--- a/decidim-core/spec/system/user_group_manage_admins_spec.rb
+++ b/decidim-core/spec/system/user_group_manage_admins_spec.rb
@@ -8,7 +8,7 @@ describe "User group manage admins", type: :system do
   let!(:admin) { create(:user, :confirmed, organization: creator.organization) }
 
   before do
-    create(:user_group_membership, user: admin, user_group: user_group, role: :admin)
+    create(:user_group_membership, user: admin, user_group:, role: :admin)
 
     switch_to_host(user_group.organization.host)
   end

--- a/decidim-core/spec/system/user_group_manage_members_spec.rb
+++ b/decidim-core/spec/system/user_group_manage_members_spec.rb
@@ -8,7 +8,7 @@ describe "User group manage members", type: :system do
   let!(:member) { create(:user, :confirmed, organization: creator.organization) }
 
   before do
-    create(:user_group_membership, user: member, user_group: user_group, role: :member)
+    create(:user_group_membership, user: member, user_group:, role: :member)
 
     switch_to_host(user_group.organization.host)
   end

--- a/decidim-core/spec/system/user_group_profile_edition_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_edition_spec.rb
@@ -8,7 +8,7 @@ describe "User group profile edition", type: :system do
   let!(:member) { create(:user, :confirmed, organization: creator.organization) }
 
   before do
-    create(:user_group_membership, user: member, user_group: user_group, role: :member)
+    create(:user_group_membership, user: member, user_group:, role: :member)
 
     switch_to_host(user_group.organization.host)
   end

--- a/decidim-core/spec/tasks/decidim_tasks_right_to_be_forgotten_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_right_to_be_forgotten_spec.rb
@@ -56,7 +56,7 @@ describe "rake decidim:right_to_be_forgotten", type: :task do
       user_ids = users.collect(&:id)
       create_forgotten_users_file(user_ids)
       task.execute
-      expect(File.exist?(Rails.root.join("log/right_to_be_forgotten.log"))).to be true
+      expect(Rails.root.join("log/right_to_be_forgotten.log").exist?).to be true
     end
   end
 

--- a/decidim-core/spec/tasks/decidim_tasks_webpacker_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_webpacker_spec.rb
@@ -14,7 +14,7 @@ describe "rake decidim:webpacker:install", type: :task do
     task.execute
 
     package_json_content = JSON.parse(File.read(package_json))
-    expect(package_json_content["dependencies"].keys).to match_array(["@decidim/browserslist-config", "@decidim/core", "@decidim/elections", "@decidim/webpacker"])
-    expect(package_json_content["devDependencies"].keys).to match_array(["@decidim/dev", "@decidim/eslint-config", "@decidim/prettier-config", "@decidim/stylelint-config"])
+    expect(package_json_content["dependencies"].keys).to contain_exactly("@decidim/browserslist-config", "@decidim/core", "@decidim/elections", "@decidim/webpacker")
+    expect(package_json_content["devDependencies"].keys).to contain_exactly("@decidim/dev", "@decidim/eslint-config", "@decidim/prettier-config", "@decidim/stylelint-config")
   end
 end

--- a/decidim-core/spec/validators/uploader_image_dimensions_validator_spec.rb
+++ b/decidim-core/spec/validators/uploader_image_dimensions_validator_spec.rb
@@ -175,7 +175,7 @@ describe UploaderImageDimensionsValidator do
 
       it "adds the correct error" do
         expect { subject }.not_to raise_error
-        expect(record.errors[:upload]).to match_array(["File cannot be processed"])
+        expect(record.errors[:upload]).to contain_exactly("File cannot be processed")
       end
     end
   end

--- a/decidim-debates/app/controllers/decidim/debates/admin/debate_closes_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debate_closes_controller.rb
@@ -8,13 +8,13 @@ module Decidim
         helper_method :debate
 
         def edit
-          enforce_permission_to :close, :debate, debate: debate
+          enforce_permission_to(:close, :debate, debate:)
 
           @form = form(Admin::CloseDebateForm).from_model(debate)
         end
 
         def update
-          enforce_permission_to :close, :debate, debate: debate
+          enforce_permission_to(:close, :debate, debate:)
 
           @form = form(Admin::CloseDebateForm).from_params(params)
 

--- a/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
@@ -38,13 +38,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :debate, debate: debate
+          enforce_permission_to(:update, :debate, debate:)
 
           @form = form(Decidim::Debates::Admin::DebateForm).from_model(debate)
         end
 
         def update
-          enforce_permission_to :update, :debate, debate: debate
+          enforce_permission_to(:update, :debate, debate:)
 
           @form = form(Decidim::Debates::Admin::DebateForm).from_params(params, current_component:)
 
@@ -62,7 +62,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :debate, debate: debate
+          enforce_permission_to(:delete, :debate, debate:)
 
           debate.destroy!
 

--- a/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
@@ -44,13 +44,13 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :edit, :debate, debate: debate
+        enforce_permission_to(:edit, :debate, debate:)
 
         @form = form(DebateForm).from_model(debate)
       end
 
       def update
-        enforce_permission_to :edit, :debate, debate: debate
+        enforce_permission_to(:edit, :debate, debate:)
 
         @form = form(DebateForm).from_params(params)
 
@@ -68,7 +68,7 @@ module Decidim
       end
 
       def close
-        enforce_permission_to :close, :debate, debate: debate
+        enforce_permission_to(:close, :debate, debate:)
 
         @form = form(CloseDebateForm).from_params(params)
 

--- a/decidim-debates/spec/services/decidim/debates/searchable_debate_resource_spec.rb
+++ b/decidim-debates/spec/services/decidim/debates/searchable_debate_resource_spec.rb
@@ -92,7 +92,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[debate.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [debate, debate2]
+              expect(results[:results]).to contain_exactly(debate, debate2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -293,7 +293,7 @@ describe "Explore debates", type: :system do
     context "with a category" do
       let(:debate) do
         debate = create(:debate, component:)
-        debate.category = create :category, participatory_space: participatory_space
+        debate.category = create(:category, participatory_space:)
         debate.save
         debate
       end

--- a/decidim-debates/spec/system/homepage_stats_spec.rb
+++ b/decidim-debates/spec/system/homepage_stats_spec.rb
@@ -10,7 +10,7 @@ describe "Homepage", type: :system do
   let!(:moderation) { create(:moderation, reportable: debates.first, hidden_at: 1.day.ago) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :stats)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :stats)
     visit decidim.root_path
   end
 

--- a/decidim-dev/lib/decidim/dev/engine.rb
+++ b/decidim-dev/lib/decidim/dev/engine.rb
@@ -8,9 +8,7 @@ module Decidim
       engine_name "decidim_dev"
 
       initializer "decidim_dev.tools" do
-        ActiveSupport.on_load :action_controller do
-          ActionController::Base.include Decidim::Dev::NeedsDevelopmentTools
-        end
+        ActiveSupport.on_load(:action_controller) { include Decidim::Dev::NeedsDevelopmentTools }
       end
 
       initializer "decidim_dev.webpacker.assets_path" do

--- a/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/answers_controller.rb
@@ -14,12 +14,12 @@ module Decidim
         end
 
         def new
-          enforce_permission_to :update, :answer, election: election, question: question
+          enforce_permission_to(:update, :answer, election:, question:)
           @form = form(AnswerForm).instance
         end
 
         def create
-          enforce_permission_to :update, :answer, election: election, question: question
+          enforce_permission_to(:update, :answer, election:, question:)
           @form = form(AnswerForm).from_params(params, election:, question:)
 
           CreateAnswer.call(@form) do
@@ -36,12 +36,12 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :answer, election: election, question: question
+          enforce_permission_to(:update, :answer, election:, question:)
           @form = form(AnswerForm).from_model(answer)
         end
 
         def update
-          enforce_permission_to :update, :answer, election: election, question: question
+          enforce_permission_to(:update, :answer, election:, question:)
           @form = form(AnswerForm).from_params(params, election:, question:)
 
           UpdateAnswer.call(@form, answer) do
@@ -66,7 +66,7 @@ module Decidim
         end
 
         def change_selected(selected)
-          enforce_permission_to :select, :answer, election: election, question: question
+          enforce_permission_to(:select, :answer, election:, question:)
 
           UpdateAnswerSelection.call(answer, selected) do
             on(:ok) do
@@ -90,7 +90,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :update, :answer, election: election, question: question
+          enforce_permission_to(:update, :answer, election:, question:)
 
           DestroyAnswer.call(answer, current_user) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
@@ -34,12 +34,12 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :election, election: election
+          enforce_permission_to(:update, :election, election:)
           @form = form(ElectionForm).from_model(election)
         end
 
         def update
-          enforce_permission_to :update, :election, election: election
+          enforce_permission_to(:update, :election, election:)
           @form = form(ElectionForm).from_params(params, current_component:)
 
           UpdateElection.call(@form, election) do
@@ -56,7 +56,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :election, election: election
+          enforce_permission_to(:delete, :election, election:)
 
           DestroyElection.call(election, current_user) do
             on(:ok) do
@@ -72,7 +72,7 @@ module Decidim
         end
 
         def publish
-          enforce_permission_to :publish, :election, election: election
+          enforce_permission_to(:publish, :election, election:)
 
           PublishElection.call(election, current_user) do
             on(:ok) do
@@ -83,7 +83,7 @@ module Decidim
         end
 
         def unpublish
-          enforce_permission_to :unpublish, :election, election: election
+          enforce_permission_to(:unpublish, :election, election:)
 
           UnpublishElection.call(election, current_user) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/elections/admin/proposals_imports_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/proposals_imports_controller.rb
@@ -8,12 +8,12 @@ module Decidim
         helper_method :election, :question, :answers, :answers
 
         def new
-          enforce_permission_to :import_proposals, :answer, election: election, question: question
+          enforce_permission_to(:import_proposals, :answer, election:, question:)
           @form = form(Admin::AnswerImportProposalsForm).instance
         end
 
         def create
-          enforce_permission_to :import_proposals, :answer, election: election, question: question
+          enforce_permission_to(:import_proposals, :answer, election:, question:)
 
           @form = form(Admin::AnswerImportProposalsForm).from_params(params, election:, question:)
 

--- a/decidim-elections/app/controllers/decidim/elections/admin/questions_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/questions_controller.rb
@@ -8,12 +8,12 @@ module Decidim
         helper_method :election, :questions, :question
 
         def new
-          enforce_permission_to :create, :question, election: election
+          enforce_permission_to(:create, :question, election:)
           @form = form(QuestionForm).instance
         end
 
         def create
-          enforce_permission_to :create, :question, election: election
+          enforce_permission_to(:create, :question, election:)
           @form = form(QuestionForm).from_params(params, election:)
 
           CreateQuestion.call(@form) do
@@ -35,12 +35,12 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :question, election: election, question: question
+          enforce_permission_to(:update, :question, election:, question:)
           @form = form(QuestionForm).from_model(question)
         end
 
         def update
-          enforce_permission_to :update, :question, election: election, question: question
+          enforce_permission_to(:update, :question, election:, question:)
           @form = form(QuestionForm).from_params(params, election:)
 
           UpdateQuestion.call(@form, question) do
@@ -57,7 +57,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :update, :question, election: election, question: question
+          enforce_permission_to(:update, :question, election:, question:)
 
           DestroyQuestion.call(question, current_user) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/elections/admin/steps_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/steps_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         helper_method :elections, :election, :current_step, :vote_stats, :bulletin_board_server, :authority_public_key, :election_unique_id, :quorum, :missing_trustees_allowed
 
         def index
-          enforce_permission_to :read, :steps, election: election
+          enforce_permission_to(:read, :steps, election:)
 
           if current_step_form_class
             @form = form(current_step_form_class).instance(election:)
@@ -19,7 +19,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :update, :steps, election: election
+          enforce_permission_to(:update, :steps, election:)
           redirect_to election_steps_path(election) && return unless params[:id] == current_step
 
           @form = form(current_step_form_class).from_params(params, election:)

--- a/decidim-elections/app/controllers/decidim/elections/admin/trustees_participatory_spaces_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/trustees_participatory_spaces_controller.rb
@@ -38,7 +38,7 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :trustee_participatory_space, trustee_participatory_space: trustee_participatory_space
+          enforce_permission_to(:update, :trustee_participatory_space, trustee_participatory_space:)
 
           UpdateTrusteeParticipatorySpace.call(trustee_participatory_space) do
             on(:ok) do |trustee|
@@ -54,7 +54,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :trustee_participatory_space, trustee_participatory_space: trustee_participatory_space
+          enforce_permission_to(:delete, :trustee_participatory_space, trustee_participatory_space:)
 
           RemoveTrusteeFromParticipatorySpace.call(trustee_participatory_space) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/elections_controller.rb
@@ -12,7 +12,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :update, :election, trustee: trustee
+          enforce_permission_to(:update, :election, trustee:)
 
           UpdateElectionBulletinBoardStatus.call(election, params[:status]) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/trustees_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/trustees_controller.rb
@@ -8,13 +8,13 @@ module Decidim
         include Decidim::FormFactory
 
         def show
-          enforce_permission_to :view, :trustee, trustee: trustee
+          enforce_permission_to(:view, :trustee, trustee:)
 
           trustee.name ||= current_user.name
         end
 
         def update
-          enforce_permission_to :update, :trustee, trustee: trustee
+          enforce_permission_to(:update, :trustee, trustee:)
 
           form = form(TrusteeForm).from_params(params, trustee:)
 

--- a/decidim-elections/app/controllers/decidim/elections/votes_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/votes_controller.rb
@@ -46,7 +46,7 @@ module Decidim
       end
 
       def update
-        enforce_permission_to :view, :election, election: election
+        enforce_permission_to(:view, :election, election:)
 
         Voter::UpdateVoteStatus.call(vote) do
           on(:ok) do
@@ -60,7 +60,7 @@ module Decidim
       end
 
       def verify
-        enforce_permission_to :view, :election, election: election
+        enforce_permission_to(:view, :election, election:)
 
         @form = form(Voter::VerifyVoteForm).instance(election:)
       end
@@ -78,7 +78,7 @@ module Decidim
       end
 
       def exit_path
-        @exit_path ||= if allowed_to? :view, :election, election: election
+        @exit_path ||= if allowed_to?(:view, :election, election:)
                          election_path(election)
                        else
                          elections_path
@@ -141,7 +141,7 @@ module Decidim
           return false
         end
 
-        enforce_permission_to :vote, :election, election: election
+        enforce_permission_to(:vote, :election, election:)
 
         true
       end

--- a/decidim-elections/app/controllers/decidim/votings/admin/monitoring_committee_election_results_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/monitoring_committee_election_results_controller.rb
@@ -20,7 +20,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :validate, :monitoring_committee_election_result, voting: current_voting, election: election
+          enforce_permission_to(:validate, :monitoring_committee_election_result, voting: current_voting, election:)
 
           if publish_results_form.pending_action
             Decidim::Elections::Admin::UpdateActionStatus.call(publish_results_form.pending_action)

--- a/decidim-elections/app/controllers/decidim/votings/admin/monitoring_committee_members_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/monitoring_committee_members_controller.rb
@@ -36,7 +36,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :monitoring_committee_member, voting: current_voting, monitoring_committee_member: monitoring_committee_member
+          enforce_permission_to(:delete, :monitoring_committee_member, voting: current_voting, monitoring_committee_member:)
 
           DestroyMonitoringCommitteeMember.call(monitoring_committee_member, current_user) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/votings/admin/monitoring_committee_polling_station_closures_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/monitoring_committee_polling_station_closures_controller.rb
@@ -21,13 +21,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :validate, :monitoring_committee_polling_station_closure, voting: current_voting, closure: closure
+          enforce_permission_to(:validate, :monitoring_committee_polling_station_closure, voting: current_voting, closure:)
 
           @form = form(MonitoringCommitteePollingStationClosureForm).from_model(closure)
         end
 
         def validate
-          enforce_permission_to :validate, :monitoring_committee_polling_station_closure, voting: current_voting, closure: closure
+          enforce_permission_to(:validate, :monitoring_committee_polling_station_closure, voting: current_voting, closure:)
 
           @form = form(MonitoringCommitteePollingStationClosureForm).from_params(params)
 

--- a/decidim-elections/app/controllers/decidim/votings/admin/polling_officers_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/polling_officers_controller.rb
@@ -33,7 +33,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :polling_officer, voting: current_voting, polling_officer: polling_officer
+          enforce_permission_to(:delete, :polling_officer, voting: current_voting, polling_officer:)
 
           DestroyPollingOfficer.call(polling_officer, current_user) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/votings/admin/polling_stations_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/polling_stations_controller.rb
@@ -38,12 +38,12 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :polling_station, voting: current_voting, polling_station: polling_station
+          enforce_permission_to(:update, :polling_station, voting: current_voting, polling_station:)
           @form = form(PollingStationForm).from_model(polling_station, voting: current_voting)
         end
 
         def update
-          enforce_permission_to :update, :polling_station, voting: current_voting, polling_station: polling_station
+          enforce_permission_to(:update, :polling_station, voting: current_voting, polling_station:)
           @form = form(PollingStationForm).from_params(params, voting: current_voting)
 
           UpdatePollingStation.call(@form, polling_station) do
@@ -60,7 +60,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :delete, :polling_station, voting: current_voting, polling_station: polling_station
+          enforce_permission_to(:delete, :polling_station, voting: current_voting, polling_station:)
 
           DestroyPollingStation.call(polling_station, current_user) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/closures_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/closures_controller.rb
@@ -8,7 +8,7 @@ module Decidim
         helper_method :election, :polling_officer, :polling_station, :closure
 
         def show
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
 
           @form = if closure.certificate_phase?
                     form(ClosureCertifyForm).instance.with_context(closure:)
@@ -18,7 +18,7 @@ module Decidim
         end
 
         def new
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
 
           @form = EnvelopesResultForm.new(
             polling_station_id: polling_station.id,
@@ -28,7 +28,7 @@ module Decidim
         end
 
         def create
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
           @form = form(EnvelopesResultForm).from_params(params).with_context(polling_officer:)
 
           CreatePollingStationClosure.call(@form) do
@@ -46,13 +46,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
 
           @form = form(ClosureResultForm).from_model(closure)
         end
 
         def update
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
           @form = form(ClosureResultForm).from_params(params)
 
           CreatePollingStationResults.call(@form, closure) do
@@ -69,7 +69,7 @@ module Decidim
         end
 
         def certify
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
 
           @form = form(ClosureCertifyForm).from_params(params).with_context(closure:)
 
@@ -87,7 +87,7 @@ module Decidim
         end
 
         def sign
-          enforce_permission_to :manage, :polling_station_results, polling_officer: polling_officer
+          enforce_permission_to(:manage, :polling_station_results, polling_officer:)
 
           @form = form(ClosureSignForm).from_params(params)
 

--- a/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/in_person_votes_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/polling_officer_zone/in_person_votes_controller.rb
@@ -15,13 +15,13 @@ module Decidim
         helper Decidim::Admin::IconLinkHelper
 
         def new
-          enforce_permission_to :manage, :in_person_vote, polling_officer: polling_officer
+          enforce_permission_to(:manage, :in_person_vote, polling_officer:)
 
           has_pending_in_person_vote?
         end
 
         def create
-          enforce_permission_to :manage, :in_person_vote, polling_officer: polling_officer
+          enforce_permission_to(:manage, :in_person_vote, polling_officer:)
 
           return if has_pending_in_person_vote?
 
@@ -37,7 +37,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :manage, :in_person_vote, polling_officer: polling_officer
+          enforce_permission_to(:manage, :in_person_vote, polling_officer:)
 
           Decidim::Votings::Voter::UpdateInPersonVoteStatus.call(in_person_vote) do
             on(:ok) do

--- a/decidim-elections/spec/commands/decidim/elections/admin/publish_election_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/publish_election_spec.rb
@@ -27,7 +27,7 @@ module Decidim::Elections::Admin
     end
 
     it "fires an event" do
-      create(:follow, followable: participatory_process, user: user)
+      create(:follow, followable: participatory_process, user:)
 
       expect(Decidim::EventsManager)
         .to receive(:publish)

--- a/decidim-elections/spec/controllers/decidim/elections/admin/answers_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/admin/answers_controller_spec.rb
@@ -49,7 +49,7 @@ module Decidim
           it "updates the election" do
             allow(controller).to receive(:election_question_answers_path).and_return("/answers")
 
-            patch :update, params: params
+            patch(:update, params:)
 
             expect(flash[:notice]).not_to be_empty
             expect(response).to have_http_status(:found)
@@ -68,7 +68,7 @@ module Decidim
               end
 
               it "displays the editing form with errors" do
-                patch :update, params: params
+                patch(:update, params:)
 
                 expect(flash[:alert]).not_to be_empty
                 expect(response).to have_http_status(:ok)

--- a/decidim-elections/spec/controllers/decidim/elections/admin/elections_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/admin/elections_controller_spec.rb
@@ -42,7 +42,7 @@ describe Decidim::Elections::Admin::ElectionsController, type: :controller do
     it "updates the election" do
       allow(controller).to receive(:elections_path).and_return("/elections")
 
-      patch :update, params: params
+      patch(:update, params:)
 
       expect(flash[:notice]).not_to be_empty
       expect(response).to have_http_status(:found)
@@ -54,7 +54,7 @@ describe Decidim::Elections::Admin::ElectionsController, type: :controller do
         let(:election) { create(:election, :with_photos, component:) }
 
         it "displays the editing form with errors" do
-          patch :update, params: params
+          patch(:update, params:)
 
           expect(flash[:alert]).not_to be_empty
           expect(response).to have_http_status(:ok)

--- a/decidim-elections/spec/forms/decidim/elections/admin/answer_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/answer_form_spec.rb
@@ -58,8 +58,8 @@ describe Decidim::Elections::Admin::AnswerForm do
 
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to match_array(["Title en cannot be blank", "Attachment Needs to be reattached"])
-        expect(subject.errors.attribute_names).to match_array([:title_en, :attachment])
+        expect(subject.errors.full_messages).to contain_exactly("Title en cannot be blank", "Attachment Needs to be reattached")
+        expect(subject.errors.attribute_names).to contain_exactly(:title_en, :attachment)
       end
     end
   end

--- a/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
@@ -82,8 +82,8 @@ describe Decidim::Elections::Admin::ElectionForm do
 
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to match_array(["Title en cannot be blank", "Attachment Needs to be reattached"])
-        expect(subject.errors.attribute_names).to match_array([:title_en, :attachment])
+        expect(subject.errors.full_messages).to contain_exactly("Title en cannot be blank", "Attachment Needs to be reattached")
+        expect(subject.errors.attribute_names).to contain_exactly(:title_en, :attachment)
       end
     end
   end

--- a/decidim-elections/spec/services/decidim/elections/current_user_vote_flow_spec.rb
+++ b/decidim-elections/spec/services/decidim/elections/current_user_vote_flow_spec.rb
@@ -73,9 +73,7 @@ module Decidim::Elections
     end
 
     context "with time dependant validations" do
-      around do |example|
-        travel_to(now) { example.run }
-      end
+      before { travel_to(now) }
 
       let(:now) { Time.new(2000, 1, 1, 0, 0, 0, 0) }
       let(:valid_token) { "M3TF3yp1KNfxclpeKGkbvIsjezpKtETOu3iEniMxWkJ86Af0d2GQZB4Yx2PbZNE9WdfleiAYaVuRq+fiC179DzWc+NzlwsdaK6WHjBte2G9LcEr7XnOhIEVcPfLI3G9jdJkL+JTxPt2T3PQnHDNnNAvcCU2sf+bWwekECGzuEZHknpM605Y2qRQfZG78Y6F17pv7u7S0e+z/CzakCcTVwOphcf2x9n+8Sy/Of7zMPO+Rbrl2KImIfpetXSvuEMcH4g/T2omCvtDvDyCPR8e8jHvlp4fAdiDU8nRX28M/xa6Vkx15MjOVfcS/NqrNMU7IxWN+xXimaausObOSkuwgb2Jq0wtoXCcDiw/SgVdr1y+o+LzqfqX+gqFL7nAgQA96WJ2SVHDo0TLybTeiPBV1MQwM/gJbRyaIjvfMKt0Q0EkPkUfJxLbt/MtUizmitLUWVNsCwqJkkV3x--rMnBzxE1CoHEpKEB--IdLlo8iGMec4qhii0/Lzwg==" }

--- a/decidim-elections/spec/services/decidim/votings/census_vote_flow_spec.rb
+++ b/decidim-elections/spec/services/decidim/votings/census_vote_flow_spec.rb
@@ -107,9 +107,7 @@ module Decidim::Votings
     end
 
     context "with time dependant validations" do
-      around do |example|
-        travel_to(now) { example.run }
-      end
+      before { travel_to(now) }
 
       let(:now) { Time.new(2000, 1, 1, 0, 0, 0, 0) }
       let(:valid_token) { "IBSjHn9uZObqElyMIc+8kDdyoyFSp7Sk5Hotc6miRSdmRHEUpEqtoWnHxAw1WPYMnWjFHdqvnlmSvhLJ6nFTUCFuUQ/BTSP/B8esCC+S12WIkpkbV2KVUt7POTjUefvbL0tL2TgDrpnjVa1iYuEhzUeMHbqTiy3skZ1hicc9G6HkWjKzj+PEVDbe9lZi1n2e7O3myZSYDdNvjfu7JaKQ5ghUP7pY1PDoqVgKq5nyonUwY1Y+dr82gM1Qtz8unxLmhoDg07GIH1bvw2oeAvhZQMdo9IuV8VckDr+8eEAfZ9ugVnxRHPx6P8XKry/TDeeADuhqfd62x7UiLjx3FRMIvqoMQAvJACwbWmWGP0zWtrS/zk9au0Vlj7kHmOmpAwT+rkQHGkyI+mWruv0ynniFqDm9R/CMJSmowpWwi1nExiLLhPNrl7EqP1GrVJSsZIczt0PNA3keTrsAqZPuyFStwdaGS9lKv1n+5WFHT/Pp2bLDNSpSdaD0I/72n99R--anVGgqjxutnUceeM--Pir5PKYxQ4DBfaQ1GAmGzg==" }

--- a/decidim-elections/spec/system/admin/admin_manages_voting_census_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_census_spec.rb
@@ -32,7 +32,7 @@ describe "Admin manages polling officers", type: :system do
 
   context "when data is invalid" do
     before do
-      create(:dataset, :data_created, voting: voting)
+      create(:dataset, :data_created, voting:)
       visit decidim_admin_votings.voting_census_path(voting)
     end
 
@@ -60,7 +60,7 @@ describe "Admin manages polling officers", type: :system do
 
   context "when data exists" do
     before do
-      create(:dataset, :data_created, :with_data, voting: voting)
+      create(:dataset, :data_created, :with_data, voting:)
       visit decidim_admin_votings.voting_census_path(voting)
     end
 
@@ -101,7 +101,7 @@ describe "Admin manages polling officers", type: :system do
 
   context "when access codes have been generated" do
     before do
-      create(:dataset, :codes_generated, voting: voting)
+      create(:dataset, :codes_generated, voting:)
       visit decidim_admin_votings.voting_census_path(voting)
     end
 
@@ -117,7 +117,7 @@ describe "Admin manages polling officers", type: :system do
 
   context "when census is frozen" do
     before do
-      create(:dataset, :frozen, voting: voting)
+      create(:dataset, :frozen, voting:)
       visit decidim_admin_votings.voting_census_path(voting)
     end
 

--- a/decidim-elections/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-elections/spec/system/homepage_content_blocks_spec.rb
@@ -8,7 +8,7 @@ describe "Homepage votings content blocks", type: :system do
   let!(:promoted_voting) { create(:voting, :promoted, organization:) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_votings)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_votings)
     switch_to_host(organization.host)
   end
 

--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
@@ -34,7 +34,7 @@ module Decidim
             end
 
             def edit
-              enforce_permission_to :update, :questionnaire, questionnaire: questionnaire
+              enforce_permission_to(:update, :questionnaire, questionnaire:)
 
               @form = form(Admin::QuestionnaireForm).from_model(questionnaire)
 
@@ -42,7 +42,7 @@ module Decidim
             end
 
             def update
-              enforce_permission_to :update, :questionnaire, questionnaire: questionnaire
+              enforce_permission_to(:update, :questionnaire, questionnaire:)
 
               params["published_at"] = Time.current if params.has_key? "save_and_publish"
               @form = form(Admin::QuestionnaireForm).from_params(params)

--- a/decidim-forms/spec/forms/decidim/forms/admin/display_condition_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/admin/display_condition_form_spec.rb
@@ -99,7 +99,7 @@ module Decidim
 
         describe "#answer_options" do
           context "when decidim_condition_question_id is set" do
-            it { expect(subject.answer_options).to contain_exactly(*condition_question.answer_options) }
+            it { expect(subject.answer_options).to match_array(condition_question.answer_options) }
           end
 
           context "when decidim_condition_question_id is not set" do
@@ -120,7 +120,7 @@ module Decidim
           end
 
           it "attaches a 'data-type' attribute to every question with its question_type" do
-            expect(questions_for_select.map { |q| q.last["data-type"] }).to contain_exactly(*questionnaire.questions.pluck(:question_type))
+            expect(questions_for_select.map { |q| q.last["data-type"] }).to match_array(questionnaire.questions.pluck(:question_type))
           end
 
           it "disables current question" do

--- a/decidim-forms/spec/models/decidim/forms/question_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/question_spec.rb
@@ -19,14 +19,14 @@ module Decidim
       end
 
       it "has an association of display_conditions" do
-        expect(subject.display_conditions).to contain_exactly(*display_conditions)
+        expect(subject.display_conditions).to match_array(display_conditions)
       end
 
       context "when there are answer_options belonging to this question" do
         let(:answer_options) { create_list(:answer_option, 3, question:) }
 
         it "has an association of answer_options" do
-          expect(subject.answer_options).to contain_exactly(*answer_options)
+          expect(subject.answer_options).to match_array(answer_options)
         end
       end
 
@@ -34,7 +34,7 @@ module Decidim
         let(:matrix_rows) { create_list(:question_matrix_row, 3, question:) }
 
         it "has an association of matrix_rows" do
-          expect(subject.matrix_rows).to contain_exactly(*matrix_rows)
+          expect(subject.matrix_rows).to match_array(matrix_rows)
         end
       end
 

--- a/decidim-initiatives/spec/forms/initiative_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_form_spec.rb
@@ -168,8 +168,8 @@ module Decidim
 
           it "adds an error to the `:attachment` field" do
             expect(subject).not_to be_valid
-            expect(subject.errors.full_messages).to match_array(["Title cannot be blank", "Attachment Needs to be reattached"])
-            expect(subject.errors.attribute_names).to match_array([:title, :attachment])
+            expect(subject.errors.full_messages).to contain_exactly("Title cannot be blank", "Attachment Needs to be reattached")
+            expect(subject.errors.attribute_names).to contain_exactly(:title, :attachment)
           end
         end
       end

--- a/decidim-initiatives/spec/forms/vote_form_spec.rb
+++ b/decidim-initiatives/spec/forms/vote_form_spec.rb
@@ -190,7 +190,7 @@ module Decidim
           let(:scoped_type) { district_1_initiative_type_scope }
 
           it "returns the scope descendants" do
-            expect(form.authorized_scope_candidates).to match_array([neighbourhood1, neighbourhood3, district1])
+            expect(form.authorized_scope_candidates).to contain_exactly(neighbourhood1, neighbourhood3, district1)
           end
         end
       end
@@ -225,13 +225,13 @@ module Decidim
               context "when the user scope has children" do
                 let(:user_scope) { district1 }
 
-                it { is_expected.to match_array([nil, city, district1]) }
+                it { is_expected.to contain_exactly(nil, city, district1) }
               end
 
               context "when the user scope is a leaf" do
                 let(:user_scope) { neighbourhood1 }
 
-                it { is_expected.to match_array([nil, city, district1, neighbourhood1]) }
+                it { is_expected.to contain_exactly(nil, city, district1, neighbourhood1) }
               end
             end
 
@@ -251,13 +251,13 @@ module Decidim
               context "when the user scope has children" do
                 let(:user_scope) { district1 }
 
-                it { is_expected.to match_array([district1]) }
+                it { is_expected.to contain_exactly(district1) }
               end
 
               context "when the user scope is a leaf" do
                 let(:user_scope) { neighbourhood1 }
 
-                it { is_expected.to match_array([district1, neighbourhood1]) }
+                it { is_expected.to contain_exactly(district1, neighbourhood1) }
               end
             end
 

--- a/decidim-initiatives/spec/queries/decidim/initiatives/admin/admin_users_spec.rb
+++ b/decidim-initiatives/spec/queries/decidim/initiatives/admin/admin_users_spec.rb
@@ -13,7 +13,7 @@ module Decidim::Initiatives
     let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins" do
-      expect(subject.query).to match_array([admin])
+      expect(subject.query).to contain_exactly(admin)
     end
   end
 end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -60,7 +60,7 @@ describe "Admin manages initiatives", type: :system do
     STATES.each do |state|
       i18n_state = I18n.t(state, scope: "decidim.admin.filters.initiatives.state_eq.values")
 
-      context "filtering collection by state: #{i18n_state}" do
+      context "when filtering collection by state: #{i18n_state}" do
         it_behaves_like "a filtered collection", options: "State", filter: i18n_state do
           let(:in_filter) { translated(initiative_with_state(state).title) }
           let(:not_in_filter) { translated(initiative_without_state(state).title) }
@@ -72,7 +72,7 @@ describe "Admin manages initiatives", type: :system do
       type = scoped_type.type
       i18n_type = type.title[I18n.locale.to_s]
 
-      context "filtering collection by type: #{i18n_type}" do
+      context "when filtering collection by type: #{i18n_type}" do
         before do
           create(:initiative, organization:, scoped_type: scoped_type1)
           create(:initiative, organization:, scoped_type: scoped_type2)
@@ -94,7 +94,7 @@ describe "Admin manages initiatives", type: :system do
     Decidim::Area.all.each do |area|
       i18n_area = area.name[I18n.locale.to_s]
 
-      context "filtering collection by area: #{i18n_area}" do
+      context "when filtering collection by area: #{i18n_area}" do
         before do
           create(:initiative, organization:, area: area1)
           create(:initiative, organization:, area: area2)

--- a/decidim-initiatives/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-initiatives/spec/system/homepage_content_blocks_spec.rb
@@ -8,7 +8,7 @@ describe "Homepage initiatives content blocks", type: :system do
   let!(:closed_initiative) { create(:initiative, :rejected, organization:) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_initiatives)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_initiatives)
     switch_to_host(organization.host)
   end
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/agenda_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/agenda_controller.rb
@@ -9,13 +9,13 @@ module Decidim
         helper_method :meeting, :agenda, :blank_agenda_item, :blank_agenda_item_child
 
         def new
-          enforce_permission_to :create, :agenda, meeting: meeting
+          enforce_permission_to(:create, :agenda, meeting:)
 
           @form = form(MeetingAgendaForm).instance
         end
 
         def create
-          enforce_permission_to :create, :agenda, meeting: meeting
+          enforce_permission_to(:create, :agenda, meeting:)
 
           @form = form(MeetingAgendaForm).from_params(params, meeting:)
 
@@ -33,13 +33,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :agenda, agenda: agenda, meeting: meeting
+          enforce_permission_to(:update, :agenda, agenda:, meeting:)
 
           @form = form(MeetingAgendaForm).from_model(agenda)
         end
 
         def update
-          enforce_permission_to :update, :agenda, agenda: agenda, meeting: meeting
+          enforce_permission_to(:update, :agenda, agenda:, meeting:)
 
           @form = form(MeetingAgendaForm).from_params(params, meeting:)
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
@@ -9,7 +9,7 @@ module Decidim
         helper_method :invites
 
         def index
-          enforce_permission_to :read_invites, :meeting, meeting: meeting
+          enforce_permission_to(:read_invites, :meeting, meeting:)
 
           @query = params[:q]
           @status = params[:status]
@@ -18,7 +18,7 @@ module Decidim
         end
 
         def create
-          enforce_permission_to :invite_attendee, :meeting, meeting: meeting
+          enforce_permission_to(:invite_attendee, :meeting, meeting:)
 
           @form = form(MeetingRegistrationInviteForm).from_params(params)
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb
@@ -10,13 +10,13 @@ module Decidim
         helper_method :meeting
 
         def edit
-          enforce_permission_to :close, :meeting, meeting: meeting
+          enforce_permission_to(:close, :meeting, meeting:)
 
           @form = form(Admin::CloseMeetingForm).from_model(meeting)
         end
 
         def update
-          enforce_permission_to :close, :meeting, meeting: meeting
+          enforce_permission_to(:close, :meeting, meeting:)
 
           @form = form(Admin::CloseMeetingForm).from_params(params.merge(proposals: meeting.sibling_scope(:proposals)))
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_copies_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_copies_controller.rb
@@ -9,13 +9,13 @@ module Decidim
         helper_method :meeting, :blank_service
 
         def new
-          enforce_permission_to :copy, :meeting, meeting: meeting
+          enforce_permission_to(:copy, :meeting, meeting:)
 
           @form = form(MeetingForm).from_model(meeting)
         end
 
         def create
-          enforce_permission_to :copy, :meeting, meeting: meeting
+          enforce_permission_to(:copy, :meeting, meeting:)
 
           @form = form(MeetingForm).from_params(params, current_component:)
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -34,13 +34,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           @form = meeting_form.from_model(meeting)
         end
 
         def update
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           @form = meeting_form.from_params(params, current_component:)
 
@@ -58,7 +58,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :meeting, meeting: meeting
+          enforce_permission_to(:destroy, :meeting, meeting:)
 
           Decidim::Meetings::Admin::DestroyMeeting.call(meeting, current_user) do
             on(:ok) do
@@ -79,7 +79,7 @@ module Decidim
         end
 
         def publish
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           Decidim::Meetings::Admin::PublishMeeting.call(meeting, current_user) do
             on(:ok) do
@@ -95,7 +95,7 @@ module Decidim
         end
 
         def unpublish
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           Decidim::Meetings::Admin::UnpublishMeeting.call(meeting, current_user) do
             on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
@@ -13,7 +13,7 @@ module Decidim
         helper Decidim::Forms::Admin::ApplicationHelper
 
         def edit
-          enforce_permission_to :update, :poll, meeting: meeting, poll: poll
+          enforce_permission_to(:update, :poll, meeting:, poll:)
 
           @form = form(Admin::QuestionnaireForm).from_model(questionnaire)
 
@@ -21,7 +21,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :update, :poll, meeting: meeting, poll: poll
+          enforce_permission_to(:update, :poll, meeting:, poll:)
 
           @form = form(Admin::QuestionnaireForm).from_params(params)
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
@@ -6,14 +6,14 @@ module Decidim
       # This controller allows an admin to manage meeting registrations from a Participatory Process
       class RegistrationsController < Admin::ApplicationController
         def edit
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           @form = MeetingRegistrationsForm.from_model(meeting)
           @validation_form = ValidateRegistrationCodeForm.new
         end
 
         def update
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           @form = MeetingRegistrationsForm.from_params(params).with_context(current_organization: meeting.organization, meeting:)
           @validation_form = ValidateRegistrationCodeForm.new
@@ -32,7 +32,7 @@ module Decidim
         end
 
         def export
-          enforce_permission_to :export_registrations, :meeting, meeting: meeting
+          enforce_permission_to(:export_registrations, :meeting, meeting:)
 
           ExportMeetingRegistrations.call(meeting, params[:format], current_user) do
             on(:ok) do |export_data|
@@ -42,7 +42,7 @@ module Decidim
         end
 
         def validate_registration_code
-          enforce_permission_to :update, :meeting, meeting: meeting
+          enforce_permission_to(:update, :meeting, meeting:)
 
           @form = MeetingRegistrationsForm.from_model(meeting)
           @validation_form = ValidateRegistrationCodeForm.from_params(params).with_context(current_organization: meeting.organization, meeting:)

--- a/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
@@ -10,13 +10,13 @@ module Decidim
       helper_method :meeting
 
       def edit
-        enforce_permission_to :close, :meeting, meeting: meeting
+        enforce_permission_to(:close, :meeting, meeting:)
 
         @form = form(CloseMeetingForm).from_model(meeting)
       end
 
       def update
-        enforce_permission_to :close, :meeting, meeting: meeting
+        enforce_permission_to(:close, :meeting, meeting:)
 
         @form = form(CloseMeetingForm).from_params(params.merge(proposals: meeting.sibling_scope(:proposals)))
 

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -65,13 +65,13 @@ module Decidim
       end
 
       def edit
-        enforce_permission_to :update, :meeting, meeting: meeting
+        enforce_permission_to(:update, :meeting, meeting:)
 
         @form = meeting_form.from_model(meeting)
       end
 
       def update
-        enforce_permission_to :update, :meeting, meeting: meeting
+        enforce_permission_to(:update, :meeting, meeting:)
 
         @form = meeting_form.from_params(params)
 
@@ -89,7 +89,7 @@ module Decidim
       end
 
       def withdraw
-        enforce_permission_to :withdraw, :meeting, meeting: meeting
+        enforce_permission_to(:withdraw, :meeting, meeting:)
 
         WithdrawMeeting.call(@meeting, current_user) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/polls/answers_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/polls/answers_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         helper_method :question
 
         def create
-          enforce_permission_to :create, :answer, question: question
+          enforce_permission_to(:create, :answer, question:)
           @form = form(AnswerForm).from_params(params, question:, current_user:)
 
           CreateAnswer.call(@form, current_user, questionnaire) do

--- a/decidim-meetings/app/controllers/decidim/meetings/polls/questions_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/polls/questions_controller.rb
@@ -15,7 +15,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :update, :question, question: question
+          enforce_permission_to(:update, :question, question:)
 
           Decidim::Meetings::Admin::UpdateQuestionStatus.call(question, current_user) do
             respond_to do |format|

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::Forms::Concerns::HasQuestionnaire
 
       def answer
-        enforce_permission_to :join, :meeting, meeting: meeting
+        enforce_permission_to(:join, :meeting, meeting:)
 
         @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token:)
 
@@ -30,7 +30,7 @@ module Decidim
       end
 
       def create
-        enforce_permission_to :register, :meeting, meeting: meeting
+        enforce_permission_to(:register, :meeting, meeting:)
 
         @form = JoinMeetingForm.from_params(params)
 
@@ -48,7 +48,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :leave, :meeting, meeting: meeting
+        enforce_permission_to(:leave, :meeting, meeting:)
 
         LeaveMeeting.call(meeting, current_user) do
           on(:ok) do
@@ -64,7 +64,7 @@ module Decidim
       end
 
       def decline_invitation
-        enforce_permission_to :decline_invitation, :meeting, meeting: meeting
+        enforce_permission_to(:decline_invitation, :meeting, meeting:)
 
         DeclineInvitation.call(meeting, current_user) do
           on(:ok) do

--- a/decidim-meetings/spec/controllers/decidim/meetings/admin/registrations_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/admin/registrations_controller_spec.rb
@@ -37,7 +37,7 @@ describe Decidim::Meetings::Admin::RegistrationsController, type: :controller do
       let(:available_slots) { nil }
 
       it "renders the form again with alert message" do
-        put :update, params: params
+        put(:update, params:)
 
         expect(subject).to render_template(:edit)
         expect(flash[:alert]).not_to be_empty
@@ -48,7 +48,7 @@ describe Decidim::Meetings::Admin::RegistrationsController, type: :controller do
       let(:reserved_slots) { nil }
 
       it "renders the index view" do
-        put :update, params: params
+        put(:update, params:)
 
         expect(subject).to render_template(:edit)
         expect(flash[:alert]).not_to be_empty

--- a/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
@@ -126,7 +126,7 @@ describe "Meetings component" do # rubocop:disable RSpec/DescribeClass
       let!(:user) { create(:user, admin: true, organization:) }
 
       it "exports all meetings from the component" do
-        expect(subject).to match_array([first_meeting, second_meeting, unpublished_meeting])
+        expect(subject).to contain_exactly(first_meeting, second_meeting, unpublished_meeting)
       end
     end
   end

--- a/decidim-meetings/spec/lib/decidim/meetings/registrations/code_generator_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/registrations/code_generator_spec.rb
@@ -18,7 +18,7 @@ module Decidim
           let(:code) { subject.generate(registration) }
 
           before do
-            create(:registration, meeting: meeting, code: existing_code)
+            create(:registration, meeting:, code: existing_code)
             expect(subject)
               .to receive(:choose)
               .with(length)

--- a/decidim-meetings/spec/queries/decidim/meetings/admin/invites_spec.rb
+++ b/decidim-meetings/spec/queries/decidim/meetings/admin/invites_spec.rb
@@ -30,7 +30,7 @@ module Decidim::Meetings::Admin
           let(:search) { "Argo" }
 
           it "returns all matching invites" do
-            expect(subject).to match_array([invites[1], invites[2]])
+            expect(subject).to contain_exactly(invites[1], invites[2])
           end
         end
 
@@ -84,7 +84,7 @@ module Decidim::Meetings::Admin
         let(:filter) { "accepted" }
 
         it 'returns the "Accepted" invites matching the query search' do
-          expect(subject).to match_array([accepted_invites[0], accepted_invites[2]])
+          expect(subject).to contain_exactly(accepted_invites[0], accepted_invites[2])
         end
       end
     end

--- a/decidim-meetings/spec/services/decidim/meetings/diff_renderer_spec.rb
+++ b/decidim-meetings/spec/services/decidim/meetings/diff_renderer_spec.rb
@@ -37,7 +37,7 @@ describe Decidim::Meetings::DiffRenderer, versioning: true do
 
     it "calculates the fields that have changed" do
       expect(subject.keys)
-        .to match_array [:title_en, :description_ca, :address, :location_ca, :location_en, :location_hints_ca, :location_hints_en, :start_time, :end_time, :decidim_scope_id]
+        .to contain_exactly(:title_en, :description_ca, :address, :location_ca, :location_en, :location_hints_ca, :location_hints_en, :start_time, :end_time, :decidim_scope_id)
     end
 
     it "has the old and new values for each field" do

--- a/decidim-meetings/spec/services/searchable_meeting_resource_spec.rb
+++ b/decidim-meetings/spec/services/searchable_meeting_resource_spec.rb
@@ -100,7 +100,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[meeting.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [meeting, meeting2]
+              expect(results[:results]).to contain_exactly(meeting, meeting2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -21,7 +21,7 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
 
   describe "listing meetings" do
     it "lists the meetings by start date" do
-      old_meeting = create(:meeting, scope: scope, services: [], component: current_component, start_time: 2.years.ago)
+      old_meeting = create(:meeting, scope:, services: [], component: current_component, start_time: 2.years.ago)
       visit current_path
 
       expect(page).to have_selector("tbody tr:first-child", text: Decidim::Meetings::MeetingPresenter.new(meeting).title)
@@ -245,7 +245,7 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
   end
 
   it "allows the user to preview an unpublished meeting" do
-    unpublished_meeting = create(:meeting, scope: scope, services: [], component: current_component)
+    unpublished_meeting = create(:meeting, scope:, services: [], component: current_component)
     visit current_path
 
     meeting_path = resource_locator(unpublished_meeting).path

--- a/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
@@ -35,7 +35,7 @@ describe "Admin filters meetings", type: :system do
     TYPES.each do |state|
       i18n_state = I18n.t(state, scope: "decidim.admin.filters.meetings.with_any_type.values")
 
-      context "filtering meetings by type: #{i18n_state}" do
+      context "when filtering meetings by type: #{i18n_state}" do
         it_behaves_like "a filtered collection", options: "Type", filter: i18n_state do
           let(:in_filter) { translated(meeting_with_type(state).title) }
           let(:not_in_filter) { translated(meeting_without_type(state).title) }

--- a/decidim-meetings/spec/system/homepage_stats_spec.rb
+++ b/decidim-meetings/spec/system/homepage_stats_spec.rb
@@ -15,7 +15,7 @@ describe "Homepage", type: :system do
   let!(:comment_moderation) { create(:moderation, reportable: comments.last, hidden_at: 1.day.ago) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :stats)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :stats)
     visit decidim.root_path
   end
 

--- a/decidim-meetings/spec/system/live_meeting_access_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_access_spec.rb
@@ -328,13 +328,8 @@ describe "Meeting live event access", type: :system do
     let(:start_time) { meeting.start_time }
     let(:end_time) { meeting.end_time }
 
-    around do |example|
-      travel_to current_time do
-        example.run
-      end
-    end
-
     before do
+      travel_to current_time
       visit_meeting
     end
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_step_activations_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_step_activations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
         include Concerns::ParticipatoryProcessAdmin
 
         def create
-          enforce_permission_to :activate, :process_step, process_step: process_step
+          enforce_permission_to(:activate, :process_step, process_step:)
 
           ActivateParticipatoryProcessStep.call(process_step, current_user) do
             on(:ok) do

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -140,7 +140,7 @@ module Decidim::ParticipatoryProcesses
           subject.call
 
           linked_processes = process.linked_participatory_space_resources(:participatory_process, "related_processes")
-          expect(linked_processes).to match_array([another_process])
+          expect(linked_processes).to contain_exactly(another_process)
         end
 
         context "when sorting by weight" do

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_spec.rb
@@ -127,7 +127,7 @@ module Decidim::ParticipatoryProcesses
             command.call
 
             linked_processes = my_process.linked_participatory_space_resources(:participatory_process, "related_processes")
-            expect(linked_processes).to match_array([another_process])
+            expect(linked_processes).to contain_exactly(another_process)
           end
         end
 

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -85,7 +85,7 @@ module Decidim
           )
 
           expect(controller.helpers.collection)
-            .to match_array([*published, *organization_groups])
+            .to match_array(published + organization_groups)
         end
       end
 

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
@@ -124,7 +124,7 @@ module Decidim
 
       describe "active_spaces" do
         it "returns the currently active ones" do
-          expect(described_class.active_spaces).to match_array [active, ends_today]
+          expect(described_class.active_spaces).to contain_exactly(active, ends_today)
           expect(described_class.active_spaces).not_to include past
           expect(described_class.active_spaces).not_to include upcoming
         end

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_type_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_type_spec.rb
@@ -31,7 +31,7 @@ module Decidim
 
       let(:processes) { create_list(:participatory_process, 2, participatory_process_type:) }
 
-      it { is_expected.to contain_exactly(*processes) }
+      it { is_expected.to match_array(processes) }
     end
   end
 end

--- a/decidim-participatory_processes/spec/queries/admin/admin_users_spec.rb
+++ b/decidim-participatory_processes/spec/queries/admin/admin_users_spec.rb
@@ -17,14 +17,14 @@ module Decidim::ParticipatoryProcesses
     let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins and participatory process admins" do
-      expect(subject.query).to match_array([admin, participatory_process_admin])
+      expect(subject.query).to contain_exactly(admin, participatory_process_admin)
     end
 
     context "when asking for organization admin users" do
       subject { described_class.new(nil, organization) }
 
       it "returns all the organization admins and participatory process admins" do
-        expect(subject.query).to match_array([admin, participatory_process_admin, other_participatory_process_admin])
+        expect(subject.query).to contain_exactly(admin, participatory_process_admin, other_participatory_process_admin)
       end
     end
   end

--- a/decidim-participatory_processes/spec/queries/admin/moderators_spec.rb
+++ b/decidim-participatory_processes/spec/queries/admin/moderators_spec.rb
@@ -20,7 +20,7 @@ module Decidim::ParticipatoryProcesses
     end
 
     it "returns the organization admins and participatory process admins" do
-      expect(subject.query).to match_array([admin, participatory_process_admin, participatory_process_moderator])
+      expect(subject.query).to contain_exactly(admin, participatory_process_admin, participatory_process_moderator)
     end
   end
 end

--- a/decidim-participatory_processes/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/valuator_checks_components_spec.rb
@@ -20,7 +20,7 @@ describe "Valuator checks components", type: :system do
   before do
     user.update(admin: false)
 
-    create(:valuation_assignment, proposal: assigned_proposal, valuator_role: valuator_role)
+    create(:valuation_assignment, proposal: assigned_proposal, valuator_role:)
 
     visit current_path
   end

--- a/decidim-participatory_processes/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-participatory_processes/spec/system/homepage_content_blocks_spec.rb
@@ -19,7 +19,7 @@ describe "Homepage processes content blocks", type: :system do
   let!(:promoted_external_process) { create(:participatory_process, :promoted) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_processes)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_processes)
     switch_to_host(organization.host)
   end
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
@@ -13,12 +13,12 @@ module Decidim
         helper Decidim::Messaging::ConversationHelper
 
         def edit
-          enforce_permission_to :create, :proposal_answer, proposal: proposal
+          enforce_permission_to(:create, :proposal_answer, proposal:)
           @form = form(Admin::ProposalAnswerForm).from_model(proposal)
         end
 
         def update
-          enforce_permission_to :create, :proposal_answer, proposal: proposal
+          enforce_permission_to(:create, :proposal_answer, proposal:)
           @notes_form = form(ProposalNoteForm).instance
           @answer_form = form(Admin::ProposalAnswerForm).from_params(params)
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_notes_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_notes_controller.rb
@@ -8,7 +8,7 @@ module Decidim
         helper_method :proposal
 
         def create
-          enforce_permission_to :create, :proposal_note, proposal: proposal
+          enforce_permission_to(:create, :proposal_note, proposal:)
           @form = form(ProposalNoteForm).from_params(params)
 
           CreateProposalNote.call(@form, proposal) do

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -122,12 +122,12 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :edit, :proposal, proposal: proposal
+          enforce_permission_to(:edit, :proposal, proposal:)
           @form = form(Admin::ProposalForm).from_model(proposal)
         end
 
         def update
-          enforce_permission_to :edit, :proposal, proposal: proposal
+          enforce_permission_to(:edit, :proposal, proposal:)
 
           @form = form(Admin::ProposalForm).from_params(params)
 

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_votes_controller.rb
@@ -12,7 +12,7 @@ module Decidim
       before_action :authenticate_user!
 
       def create
-        enforce_permission_to :vote, :proposal, proposal: proposal
+        enforce_permission_to(:vote, :proposal, proposal:)
         @from_proposals_list = params[:from_proposals_list] == "true"
 
         VoteProposal.call(proposal, current_user) do
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def destroy
-        enforce_permission_to :unvote, :proposal, proposal: proposal
+        enforce_permission_to(:unvote, :proposal, proposal:)
         @from_proposals_list = params[:from_proposals_list] == "true"
 
         UnvoteProposal.call(proposal, current_user) do

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
@@ -107,7 +107,7 @@ module Decidim
                   proposal = Decidim::Proposals::Proposal.last
                   linked_proposals = meeting_as_author.linked_resources(:proposal, "proposals_from_meeting")
 
-                  expect(linked_proposals).to match_array([proposal, another_proposal])
+                  expect(linked_proposals).to contain_exactly(proposal, another_proposal)
                 end
               end
             end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -86,7 +86,7 @@ module Decidim
                 end.to change { Proposal.where(component: current_component).count }.by(1)
 
                 titles = Proposal.where(component: current_component).map(&:title)
-                expect(titles).to match_array([proposal.title, second_proposal.title])
+                expect(titles).to contain_exactly(proposal.title, second_proposal.title)
               end
 
               context "and the current component was not published" do
@@ -98,7 +98,7 @@ module Decidim
                   end.to change { Proposal.where(component: current_component).count }.by(1)
 
                   titles = Proposal.where(component: current_component).map(&:title)
-                  expect(titles).to match_array([proposal.title, second_proposal.title])
+                  expect(titles).to contain_exactly(proposal.title, second_proposal.title)
                 end
               end
             end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
@@ -33,8 +33,8 @@ module Decidim
               event: "decidim.events.proposals.proposal_accepted",
               event_class: Decidim::Proposals::AcceptedProposalEvent,
               resource: proposal,
-              affected_users: match_array([proposal.creator_author]),
-              followers: match_array([follower])
+              affected_users: contain_exactly(proposal.creator_author),
+              followers: contain_exactly(follower)
             )
 
           subject
@@ -59,8 +59,8 @@ module Decidim
                 event: "decidim.events.proposals.proposal_rejected",
                 event_class: Decidim::Proposals::RejectedProposalEvent,
                 resource: proposal,
-                affected_users: match_array([proposal.creator_author]),
-                followers: match_array([follower])
+                affected_users: contain_exactly(proposal.creator_author),
+                followers: contain_exactly(follower)
               )
 
             subject

--- a/decidim-proposals/spec/controllers/decidim/proposals/admin/participatory_texts_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/admin/participatory_texts_controller_spec.rb
@@ -33,7 +33,7 @@ module Decidim
             let(:title) { {} }
 
             it "renders new_import template" do
-              post :import, params: params
+              post(:import, params:)
               expect(response).to render_template(:new_import)
               expect(flash[:alert]).to eq("The form is invalid!")
             end
@@ -41,7 +41,7 @@ module Decidim
 
           context "when the command succeeds" do
             it "parses the document" do
-              post :import, params: params
+              post(:import, params:)
               expect(response).to redirect_to EngineRouter.admin_proxy(component).participatory_texts_path
               expect(flash[:notice].starts_with?("Congratulations")).to be true
             end

--- a/decidim-proposals/spec/controllers/decidim/proposals/admin/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/admin/proposals_controller_spec.rb
@@ -37,7 +37,7 @@ describe Decidim::Proposals::Admin::ProposalsController, type: :controller do
     it "updates the proposal" do
       allow(controller).to receive(:proposals_path).and_return("/proposals")
 
-      patch :update, params: params
+      patch(:update, params:)
 
       expect(flash[:notice]).not_to be_empty
       expect(response).to have_http_status(:found)
@@ -57,7 +57,7 @@ describe Decidim::Proposals::Admin::ProposalsController, type: :controller do
         let(:proposal) { create(:proposal, :official, :with_photo, component:) }
 
         it "displays the editing form with errors" do
-          patch :update, params: params
+          patch(:update, params:)
 
           expect(flash[:alert]).not_to be_empty
           expect(response).to have_http_status(:ok)

--- a/decidim-proposals/spec/controllers/decidim/proposals/collaborative_drafts_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/collaborative_drafts_controller_spec.rb
@@ -51,7 +51,7 @@ module Decidim
 
         describe "GET new" do
           it "renders the empty form" do
-            get :new, params: params
+            get(:new, params:)
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:new)
           end
@@ -73,14 +73,14 @@ module Decidim
           let(:component) { create(:proposal_component, :with_collaborative_drafts_enabled) }
 
           it "redirects" do
-            post :create, params: params
+            post(:create, params:)
             expect(response).to have_http_status(:found)
           end
         end
 
         context "when creation is enabled" do
           it "creates a collaborative draft" do
-            post :create, params: params
+            post(:create, params:)
             expect(response).to have_http_status(:found)
           end
         end
@@ -112,7 +112,7 @@ module Decidim
         end
 
         it "updates the collaborative draft" do
-          put :update, params: params
+          put(:update, params:)
           expect(assigns(:collaborative_draft)).to be_kind_of(Decidim::Proposals::CollaborativeDraft)
           expect(response).to have_http_status(:found)
         end

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -44,8 +44,8 @@ module Decidim
           end
 
           it "sets two different collections" do
-            geocoded_proposals = create_list(:proposal, 10, component: component, latitude: 1.1, longitude: 2.2)
-            _non_geocoded_proposals = create_list(:proposal, 2, component: component, latitude: nil, longitude: nil)
+            geocoded_proposals = create_list(:proposal, 10, component:, latitude: 1.1, longitude: 2.2)
+            _non_geocoded_proposals = create_list(:proposal, 2, component:, latitude: nil, longitude: nil)
 
             get :index
             expect(response).to have_http_status(:ok)
@@ -88,7 +88,7 @@ module Decidim
 
         context "when NO draft proposals exist" do
           it "renders the empty form" do
-            get :new, params: params
+            get(:new, params:)
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:new)
           end
@@ -98,7 +98,7 @@ module Decidim
           let!(:others_draft) { create(:proposal, :draft, component:) }
 
           it "renders the empty form" do
-            get :new, params: params
+            get(:new, params:)
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:new)
           end
@@ -112,7 +112,7 @@ module Decidim
           let(:component) { create(:proposal_component) }
 
           it "raises an error" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(flash[:alert]).not_to be_empty
           end
@@ -129,7 +129,7 @@ module Decidim
           end
 
           it "creates a proposal" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(flash[:notice]).not_to be_empty
             expect(response).to have_http_status(:found)
@@ -156,7 +156,7 @@ module Decidim
         before { sign_in user }
 
         it "updates the proposal" do
-          patch :update, params: params
+          patch(:update, params:)
 
           expect(flash[:notice]).not_to be_empty
           expect(response).to have_http_status(:found)
@@ -176,7 +176,7 @@ module Decidim
             let(:proposal) { create(:proposal, :with_photo, :with_document, component:, users: [user]) }
 
             it "displays the editing form with errors" do
-              patch :update, params: params
+              patch(:update, params:)
 
               expect(flash[:alert]).not_to be_empty
               expect(response).to have_http_status(:ok)
@@ -202,28 +202,28 @@ module Decidim
 
         context "when you try to preview a proposal created by another user" do
           it "will not render the preview page" do
-            get :preview, params: params
+            get(:preview, params:)
             expect(subject).not_to render_template(:preview)
           end
         end
 
         context "when you try to complete a proposal created by another user" do
           it "will not render the complete page" do
-            get :complete, params: params
+            get(:complete, params:)
             expect(subject).not_to render_template(:complete)
           end
         end
 
         context "when you try to compare a proposal created by another user" do
           it "will not render the compare page" do
-            get :compare, params: params
+            get(:compare, params:)
             expect(subject).not_to render_template(:compare)
           end
         end
 
         context "when you try to publish a proposal created by another user" do
           it "will not render the publish page" do
-            post :publish, params: params
+            post(:publish, params:)
             expect(subject).not_to render_template(:publish)
           end
         end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -280,7 +280,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       let!(:user) { create(:user, admin: true, organization:) }
 
       it "exports all proposals from the component" do
-        expect(subject).to match_array([unassigned_proposal, assigned_proposal])
+        expect(subject).to contain_exactly(unassigned_proposal, assigned_proposal)
       end
     end
 

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -80,7 +80,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       let(:stats_name) { :supports_count }
 
       before do
-        create_list(:proposal_vote, 2, proposal: proposal)
+        create_list(:proposal_vote, 2, proposal:)
         create_list(:proposal_vote, 3, proposal: hidden_proposal)
       end
 

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -50,8 +50,8 @@ describe Decidim::Proposals::Import::ProposalCreator do
   describe "#resource_attributes" do
     it "returns the attributes hash" do
       expect(subject.resource_attributes).to eq(
-        :"title/en" => data[:"title/en"],
-        :"body/en" => data[:"body/en"],
+        "title/en": data[:"title/en"],
+        "body/en": data[:"body/en"],
         category: data[:category],
         scope: data[:scope],
         address: data[:address],

--- a/decidim-proposals/spec/models/decidim/proposals/collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/collaborative_draft_spec.rb
@@ -39,7 +39,7 @@ module Decidim
 
         context "when user is author" do
           let(:collaborative_draft) do
-            cd = create(:collaborative_draft, component: component, updated_at: Time.current)
+            cd = create(:collaborative_draft, component:, updated_at: Time.current)
             Decidim::Coauthorship.create(author:, coauthorable: cd)
             cd
           end
@@ -50,7 +50,7 @@ module Decidim
         context "when created from user group and user is admin" do
           let(:user_group) { create(:user_group, :verified, users: [author], organization: author.organization) }
           let(:collaborative_draft) do
-            cd = create(:collaborative_draft, component: component, updated_at: Time.current)
+            cd = create(:collaborative_draft, component:, updated_at: Time.current)
             Decidim::Coauthorship.create(author:, decidim_user_group_id: user_group.id, coauthorable: cd)
             cd
           end

--- a/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/searchable_proposal_resource_spec.rb
@@ -151,7 +151,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[proposal.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [proposal, proposal2]
+              expect(results[:results]).to contain_exactly(proposal, proposal2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -289,11 +289,11 @@ shared_examples "a proposal form" do |options|
         expect(subject).not_to be_valid
 
         if options[:i18n]
-          expect(subject.errors.full_messages).to match_array(["Title en cannot be blank", "Add photos Needs to be reattached"])
-          expect(subject.errors.attribute_names).to match_array([:title_en, :add_photos])
+          expect(subject.errors.full_messages).to contain_exactly("Title en cannot be blank", "Add photos Needs to be reattached")
+          expect(subject.errors.attribute_names).to contain_exactly(:title_en, :add_photos)
         else
-          expect(subject.errors.full_messages).to match_array(["Title cannot be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached"])
-          expect(subject.errors.attribute_names).to match_array([:title, :add_photos])
+          expect(subject.errors.full_messages).to contain_exactly("Title cannot be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached")
+          expect(subject.errors.attribute_names).to contain_exactly(:title, :add_photos)
         end
       end
     end

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -244,6 +244,7 @@ shared_examples "proposals wizards" do |options|
       end
     end
   end
+
   shared_examples_for "with address" do
     let!(:component) do
       create(:proposal_component,

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
@@ -60,7 +60,7 @@ describe "Admin manages proposals valuators", type: :system do
     let(:assigned_proposal) { proposal }
 
     before do
-      create(:valuation_assignment, proposal: proposal, valuator_role: valuator_role)
+      create(:valuation_assignment, proposal:, valuator_role:)
 
       visit current_path
     end
@@ -84,7 +84,7 @@ describe "Admin manages proposals valuators", type: :system do
     let(:assigned_proposal) { proposal }
 
     before do
-      create(:valuation_assignment, proposal: proposal, valuator_role: valuator_role)
+      create(:valuation_assignment, proposal:, valuator_role:)
 
       visit current_path
 
@@ -126,7 +126,7 @@ describe "Admin manages proposals valuators", type: :system do
     let(:assigned_proposal) { proposal }
 
     before do
-      create(:valuation_assignment, proposal: proposal, valuator_role: valuator_role)
+      create(:valuation_assignment, proposal:, valuator_role:)
 
       visit current_path
       within find("tr", text: translated(proposal.title)) do

--- a/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
@@ -33,7 +33,7 @@ describe "Admin filters proposals", type: :system do
     STATES.each do |state|
       i18n_state = I18n.t(state, scope: "decidim.admin.filters.proposals.state_eq.values")
 
-      context "filtering proposals by state: #{i18n_state}" do
+      context "when filtering proposals by state: #{i18n_state}" do
         it_behaves_like "a filtered collection", options: "State", filter: i18n_state do
           let(:in_filter) { translated(proposal_with_state(state).title) }
           let(:not_in_filter) { translated(proposal_without_state(state).title) }

--- a/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
@@ -22,7 +22,7 @@ describe "Valuator manages proposals", type: :system do
   before do
     user.update(admin: false)
 
-    create(:valuation_assignment, proposal: assigned_proposal, valuator_role: valuator_role)
+    create(:valuation_assignment, proposal: assigned_proposal, valuator_role:)
     create(:valuation_assignment, proposal: assigned_proposal, valuator_role: another_valuator_role)
 
     visit current_path

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -102,7 +102,7 @@ describe "Admin views proposal details from admin", type: :system do
     end
 
     it "shows the ranking by supports" do
-      another_proposal = create(:proposal, component: component)
+      another_proposal = create(:proposal, component:)
       create(:proposal_vote, proposal: another_proposal)
       go_to_admin_proposal_page(proposal)
 
@@ -124,7 +124,7 @@ describe "Admin views proposal details from admin", type: :system do
     end
 
     it "shows the ranking by endorsements" do
-      another_proposal = create(:proposal, component: component)
+      another_proposal = create(:proposal, component:)
       create(:endorsement, resource: another_proposal, author: build(:user, organization:))
       go_to_admin_proposal_page(proposal)
 

--- a/decidim-proposals/spec/system/homepage_stats_spec.rb
+++ b/decidim-proposals/spec/system/homepage_stats_spec.rb
@@ -15,7 +15,7 @@ describe "Homepage", type: :system do
   let!(:comment_moderation) { create(:moderation, reportable: comments.last, hidden_at: 1.day.ago) }
 
   before do
-    create(:content_block, organization: organization, scope_name: :homepage, manifest_name: :stats)
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :stats)
     visit decidim.root_path
   end
 

--- a/decidim-sortitions/app/controllers/decidim/sortitions/admin/sortitions_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/admin/sortitions_controller.rb
@@ -16,13 +16,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :sortition, sortition: sortition
+          enforce_permission_to(:update, :sortition, sortition:)
 
           @form = edit_sortition_form.from_model(sortition, current_participatory_space:)
         end
 
         def update
-          enforce_permission_to :update, :sortition, sortition: sortition
+          enforce_permission_to(:update, :sortition, sortition:)
 
           @form = edit_sortition_form.from_params(params, current_participatory_space:)
           UpdateSortition.call(@form) do
@@ -62,13 +62,13 @@ module Decidim
         end
 
         def confirm_destroy
-          enforce_permission_to :destroy, :sortition, sortition: sortition
+          enforce_permission_to(:destroy, :sortition, sortition:)
 
           @form = destroy_sortition_form.from_model(sortition, current_participatory_space:)
         end
 
         def destroy
-          enforce_permission_to :destroy, :sortition, sortition: sortition
+          enforce_permission_to(:destroy, :sortition, sortition:)
 
           @form = destroy_sortition_form.from_params(params, current_participatory_space:)
           DestroySortition.call(@form) do

--- a/decidim-sortitions/spec/controllers/decidim/sortitions/admin/sortitions_controller_spec.rb
+++ b/decidim-sortitions/spec/controllers/decidim/sortitions/admin/sortitions_controller_spec.rb
@@ -29,7 +29,7 @@ module Decidim
           end
 
           it "renders the show template" do
-            get :show, params: params
+            get(:show, params:)
             expect(response).to render_template(:show)
           end
         end
@@ -40,7 +40,7 @@ module Decidim
           end
 
           it "renders the new template" do
-            get :new, params: params
+            get(:new, params:)
             expect(response).to render_template(:new)
           end
         end
@@ -80,7 +80,7 @@ module Decidim
             let(:decidim_proposals_component_id) { nil }
 
             it "renders the new template" do
-              post :create, params: params
+              post(:create, params:)
               expect(response).to render_template(:new)
             end
           end
@@ -102,7 +102,7 @@ module Decidim
                 expect(params).to eq(action: :show, id: Sortition.last.id)
               end
 
-              post :create, params: params
+              post(:create, params:)
               expect(Sortition.last.author).to eq(user)
             end
           end
@@ -119,7 +119,7 @@ module Decidim
           end
 
           it "renders the confirm_destroy template" do
-            get :confirm_destroy, params: params
+            get(:confirm_destroy, params:)
             expect(response).to render_template(:confirm_destroy)
           end
         end
@@ -152,7 +152,7 @@ module Decidim
             end
 
             it "renders the confirm_destroy template" do
-              delete :destroy, params: params
+              delete(:destroy, params:)
               expect(response).to render_template(:confirm_destroy)
             end
           end
@@ -177,7 +177,7 @@ module Decidim
           end
 
           it "renders the edit template" do
-            get :edit, params: params
+            get(:edit, params:)
             expect(response).to render_template(:edit)
           end
         end
@@ -218,7 +218,7 @@ module Decidim
             end
 
             it "renders the edit template" do
-              patch :update, params: params
+              patch(:update, params:)
               expect(response).to render_template(:edit)
             end
           end

--- a/decidim-surveys/spec/controllers/decidim/surveys/admin/surveys_controller_spec.rb
+++ b/decidim-surveys/spec/controllers/decidim/surveys/admin/surveys_controller_spec.rb
@@ -37,7 +37,7 @@ module Decidim
           end
 
           it "renders the index template" do
-            get :index, params: params
+            get(:index, params:)
             expect(response).to render_template(:index)
           end
         end
@@ -53,7 +53,7 @@ module Decidim
           end
 
           it "renders the show template" do
-            get :show, params: params
+            get(:show, params:)
             expect(response).to render_template(:show)
           end
         end
@@ -70,7 +70,7 @@ module Decidim
           end
 
           it "redirects with a flash notice message" do
-            get :export_response, params: params
+            get(:export_response, params:)
 
             expect(response).to be_redirect
             expect(flash[:notice]).to be_present

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -21,7 +21,7 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
 
     context "with answers" do
       before do
-        survey = create(:survey, component: component)
+        survey = create(:survey, component:)
         create(:answer, questionnaire: survey.questionnaire)
       end
 

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -54,8 +54,8 @@ module Decidim
 
             expect(organization.name).to eq("Gotham City")
             expect(organization.host).to eq("decide.gotham.gov")
-            expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
-            expect(organization.external_domain_whitelist).to match_array(["decidim.org", "github.com"])
+            expect(organization.secondary_hosts).to contain_exactly("foo.gotham.gov", "bar.gotham.gov")
+            expect(organization.external_domain_whitelist).to contain_exactly("decidim.org", "github.com")
             expect(organization.smtp_settings["from"]).to eq("Decide Gotham <decide@gotham.gov>")
             expect(organization.smtp_settings["from_email"]).to eq("decide@gotham.gov")
             expect(organization.omniauth_settings["omniauth_settings_facebook_enabled"]).to be(true)

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -50,7 +50,7 @@ module Decidim
 
             expect(organization.name).to eq("Gotham City")
             expect(organization.host).to eq("decide.gotham.gov")
-            expect(organization.secondary_hosts).to match_array(["foo.gotham.gov", "bar.gotham.gov"])
+            expect(organization.secondary_hosts).to contain_exactly("foo.gotham.gov", "bar.gotham.gov")
             expect(organization.users_registration_mode).to eq("existing")
             expect(organization.smtp_settings["from"]).to eq("Decide Gotham <decide@gotham.gov>")
             expect(organization.smtp_settings["from_email"]).to eq("decide@gotham.gov")

--- a/decidim-templates/app/controllers/decidim/templates/admin/block_user_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/block_user_templates_controller.rb
@@ -8,7 +8,7 @@ module Decidim
         include Decidim::Paginable
 
         def fetch
-          enforce_permission_to :read, :template, template: template
+          enforce_permission_to(:read, :template, template:)
 
           response_object = {
             template: translated_attribute(template.description)
@@ -38,7 +38,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :template, template: template
+          enforce_permission_to(:destroy, :template, template:)
 
           DestroyTemplate.call(template, current_user) do
             on(:ok) do
@@ -49,7 +49,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :update, :template, template: template
+          enforce_permission_to(:update, :template, template:)
           @form = form(TemplateForm).from_params(params)
           UpdateTemplate.call(template, @form, current_user) do
             on(:ok) do
@@ -66,7 +66,7 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :template, template: template
+          enforce_permission_to(:update, :template, template:)
           @form = form(TemplateForm).from_model(template)
         end
 

--- a/decidim-templates/app/controllers/decidim/templates/admin/questionnaire_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/questionnaire_templates_controller.rb
@@ -68,13 +68,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :template, template: template
+          enforce_permission_to(:update, :template, template:)
           @form = form(TemplateForm).from_model(template)
           @preview_form = form(Decidim::Forms::QuestionnaireForm).from_model(template.templatable)
         end
 
         def update
-          enforce_permission_to :update, :template, template: template
+          enforce_permission_to(:update, :template, template:)
           @form = form(TemplateForm).from_params(params)
           UpdateTemplate.call(template, @form, current_user) do
             on(:ok) do |questionnaire_template|
@@ -91,7 +91,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :template, template: template
+          enforce_permission_to(:destroy, :template, template:)
 
           DestroyQuestionnaireTemplate.call(template, current_user) do
             on(:ok) do

--- a/decidim-verifications/app/controllers/concerns/decidim/verifications/renewable.rb
+++ b/decidim-verifications/app/controllers/concerns/decidim/verifications/renewable.rb
@@ -9,7 +9,7 @@ module Decidim
       extend ActiveSupport::Concern
       included do
         def renew
-          enforce_permission_to :renew, :authorization, authorization: authorization
+          enforce_permission_to(:renew, :authorization, authorization:)
 
           DestroyUserAuthorization.call(authorization) do
             on(:ok, authorization) do
@@ -25,7 +25,7 @@ module Decidim
         end
 
         def renew_modal
-          enforce_permission_to :renew, :authorization, authorization: authorization
+          enforce_permission_to(:renew, :authorization, authorization:)
 
           respond_to do |format|
             format.html { render layout: nil }

--- a/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -9,13 +9,13 @@ module Decidim
         helper_method :authorization
 
         def new
-          enforce_permission_to :create, :authorization, authorization: authorization
+          enforce_permission_to(:create, :authorization, authorization:)
 
           @form = MobilePhoneForm.new
         end
 
         def create
-          enforce_permission_to :create, :authorization, authorization: authorization
+          enforce_permission_to(:create, :authorization, authorization:)
 
           @form = MobilePhoneForm.from_params(params.merge(user: current_user))
 
@@ -33,13 +33,13 @@ module Decidim
         end
 
         def edit
-          enforce_permission_to :update, :authorization, authorization: authorization
+          enforce_permission_to(:update, :authorization, authorization:)
 
           @form = ConfirmationForm.from_params(params)
         end
 
         def update
-          enforce_permission_to :update, :authorization, authorization: authorization
+          enforce_permission_to(:update, :authorization, authorization:)
 
           @form = ConfirmationForm.from_params(params)
 
@@ -58,7 +58,7 @@ module Decidim
         end
 
         def destroy
-          enforce_permission_to :destroy, :authorization, authorization: authorization
+          enforce_permission_to(:destroy, :authorization, authorization:)
 
           authorization.destroy!
           flash[:notice] = t("authorizations.destroy.success", scope: "decidim.verifications.sms")

--- a/decidim-verifications/spec/services/decidim/authorization_handler_spec.rb
+++ b/decidim-verifications/spec/services/decidim/authorization_handler_spec.rb
@@ -22,8 +22,8 @@ module Decidim
     describe "form_attributes" do
       subject { handler.form_attributes }
 
-      it { is_expected.to match_array(["handler_name"]) }
-      it { is_expected.not_to match_array([:id, :user]) }
+      it { is_expected.to contain_exactly("handler_name") }
+      it { is_expected.not_to contain_exactly(:id, :user) }
     end
 
     describe "to_partial_path" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### Testing
Make sure the pipeline is green. 

- [x] Capybara/NegationMatcher
- [x] Style/RedundantConstantBase
- [x] Style/MagicCommentFormat
- [x] Lint/RedundantCopDisableDirective
- [x] Lint/DuplicateMagicComment
- [ ] Capybara/SpecificMatcher
- [ ] Capybara/SpecificFinders
- [ ] Capybara/SpecificActions
- [ ] Capybara/CurrentPathExpectation
- [ ] Style/RedundantStringEscape
- [ ] Style/MapToSet
- [x] Style/HashSyntax
- [ ] Style/Semicolon
- [ ] Style/ConcatArrayLiterals
- [ ] Style/ClassEqualityComparison
- [ ] Style/RedundantParentheses
- [ ] Style/ArrayIntersect
- [ ] Style/MinMaxComparison
- [ ] Style/RedundantRegexpEscape
- [ ] RSpec/IndexedLet
- [ ] RSpec/Rails/InferredSpecType
- [ ] RSpec/ClassCheck
- [ ] RSpec/NoExpectationExample
- [ ] RSpec/SortMetadata
- [x] RSpec/FactoryBot/ConsistentParenthesesStyle
- [x] RSpec/MatchArray
- [ ] Rails/ActionControllerFlashBeforeRender
- [x] RSpec/ContainExactly
- [x] RSpec/Rails/TravelAround
- [ ] Style/EachForSimpleLoop
- [x] RSpec/ContextWording
- [x] RSpec/EmptyLineAfterExampleGroup
- [x] Rails/ActiveSupportOnLoad
- [ ] RSpec/SkipBlockInsideExample
- [x] RSpec/Rails/HaveHttpStatus
- [ ] Rails/HelperInstanceVariable
- [x] RSpec/BeEmpty
- [x] Rails/RootPathnameMethods

:hearts: Thank you!
