### PR TITLE
Implement hamburger menu design for desktop

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/sticky_header/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/sticky_header/controller.js
@@ -41,7 +41,7 @@ export default class extends Controller {
     const menuBarContainer = document.querySelector("#menu-bar-container");
 
     // Calculate margin based on screen size and sticky header height
-    const marginTop = this.isMaxScreenSize("md")
+    const marginTop = this.isMaxScreenSize("sm")
       ? this.element.offsetHeight
       : 0;
 

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -21,6 +21,7 @@ const menuContainer = document.getElementById("dropdown-menu-main-desktop");
 const menuButton = document.getElementById("main-dropdown-summary-desktop");
 const content = document.getElementById("content");
 const footer = document.querySelector("footer");
+const menuBar = document.querySelector("#menu-bar-container");
 
 
 menuButton.addEventListener("click", function () {
@@ -30,10 +31,12 @@ menuButton.addEventListener("click", function () {
     menuContainer.setAttribute("aria-hidden", "false");
     content.style.opacity = "0.3";
     footer.style.opacity = "0.3";
+    menuBar.style.opacity = "0.3";
   } else {
     menuContainer.setAttribute("aria-hidden", "true");
     content.style.opacity = "1";
     footer.style.opacity = "1";
+    menuBar.style.opacity = "1";
   }
 });
 

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -16,3 +16,34 @@ document.addEventListener("turbo:load", () => {
     })
   }
 });
+
+const menuContainer = document.getElementById("dropdown-menu-main-desktop");
+const menuButton = document.getElementById("main-dropdown-summary-desktop");
+const content = document.getElementById("content");
+const footer = document.querySelector("footer");
+
+
+menuButton.addEventListener("click", function (e) {
+  const isHidden = menuContainer.getAttribute("aria-hidden") === "true";
+
+  if (isHidden) {
+    menuContainer.setAttribute("aria-hidden", "false");
+    content.style.opacity = "0.3";
+    footer.style.opacity = "0.3";
+  } else {
+    menuContainer.setAttribute("aria-hidden", "true");
+    content.style.opacity = "1";
+    footer.style.opacity = "1";
+  }
+});
+
+document.addEventListener("click", function (e) {
+  const isOpen = menuContainer.getAttribute("aria-hidden") === "false";
+  const clickedInsideMenu = menuContainer.contains(e.target) || menuButton.contains(e.target);
+
+  if (isOpen && !clickedInsideMenu) {
+    menuContainer.setAttribute("aria-hidden", "true");
+    content.style.opacity = "1";
+    footer.style.opacity = "1";
+  }
+});

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -23,7 +23,7 @@ const content = document.getElementById("content");
 const footer = document.querySelector("footer");
 
 
-menuButton.addEventListener("click", function (e) {
+menuButton.addEventListener("click", function () {
   const isHidden = menuContainer.getAttribute("aria-hidden") === "true";
 
   if (isHidden) {
@@ -37,9 +37,9 @@ menuButton.addEventListener("click", function (e) {
   }
 });
 
-document.addEventListener("click", function (e) {
+document.addEventListener("click", function (event) {
   const isOpen = menuContainer.getAttribute("aria-hidden") === "false";
-  const clickedInsideMenu = menuContainer.contains(e.target) || menuButton.contains(e.target);
+  const clickedInsideMenu = menuContainer.contains(event.target) || menuButton.contains(event.target);
 
   if (isOpen && !clickedInsideMenu) {
     menuContainer.setAttribute("aria-hidden", "true");

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -44,6 +44,12 @@
   }
 }
 
+[data-target="dropdown-menu-main-desktop"] {
+  > span:first-of-type {
+    @apply block
+  }
+}
+
 [data-target="dropdown-menu-participatory-space"],
 [data-target="dropdown-menu-order"],
 [data-target="dropdown-menu-resource"],

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -23,13 +23,23 @@
   }
 
   &[aria-expanded="false"] > svg:last-of-type,
-  &[aria-expanded="true"] > svg:first-of-type {
+  &[aria-expanded="true"] > svg:first-of-type,
+  &[aria-expanded="false"] > span:last-of-type,
+  &[aria-expanded="true"] > span:first-of-type {
     @apply hidden;
   }
 
   &[aria-expanded="true"] > svg:last-of-type,
-  &[aria-expanded="false"] > svg:first-of-type {
+  &[aria-expanded="false"] > svg:first-of-type,
+  &[aria-expanded="true"] > span:last-of-type,
+  &[aria-expanded="false"] > span:first-of-type {
     @apply block;
+  }
+}
+
+[data-target="dropdown-menu-main-desktop"] {
+  > span:first-of-type {
+    @apply block
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -39,7 +39,7 @@
 
 [data-target="dropdown-menu-main-desktop"] {
   > span:first-of-type {
-    @apply block
+    @apply block;
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -37,7 +37,8 @@
   }
 }
 
-[data-target="dropdown-menu-main-desktop"] {
+[data-target="dropdown-menu-main-desktop"],
+[data-target="dropdown-menu-main-mobile"] {
   > span:first-of-type {
     @apply block;
   }

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -1,6 +1,6 @@
 header {
   .admin-bar {
-    @apply container flex flex-wrap items-center justify-start gap-y-2 gap-x-4 md:px-0;
+    @apply container flex flex-wrap items-center justify-start gap-y-2 gap-x-4;
 
     &__container {
       @apply bg-tertiary py-2;
@@ -35,18 +35,18 @@ header {
   }
 
   #sticky-header-container {
-    @apply fixed w-full top-0 shadow-lg z-40 bg-white md:relative transition-top duration-300;
+    @apply fixed w-full top-0 z-40 bg-white md:relative transition-top duration-300;
   }
 
   .main-bar {
-    @apply container flex justify-between gap-4 items-center py-5 h-24 px-4 md:px-0;
+    @apply container flex justify-between gap-4 items-center py-5 h-20;
 
     &--focus-mode-back-button {
       @apply h-16 lg:h-24;
     }
 
     &__container {
-      @apply relative w-full;
+      @apply relative w-full flex justify-between;
     }
 
     &__logo {
@@ -69,10 +69,10 @@ header {
       }
 
       input[type="text"] {
-        @apply block bg-transparent w-full px-4 py-1.5 h-full;
+        @apply block bg-transparent w-full px-4 py-2 h-full;
 
         &::placeholder {
-          @apply text-gray-8 ltr:pl-6 rtl:pr-6;
+          @apply text-gray-8 text-sm ltr:pl-6 rtl:pr-6;
         }
       }
 
@@ -94,7 +94,7 @@ header {
     }
 
     &__menu-mobile {
-      @apply lg:hidden flex flex-row-reverse items-center;
+      @apply lg:hidden flex flex-row-reverse items-center gap-x-3;
     }
 
     &__links-desktop,
@@ -176,7 +176,7 @@ header {
       }
 
       svg + span {
-        @apply text-md leading-[22px] first-letter:uppercase;
+        @apply text-md leading-[22px] first-letter:uppercase font-semibold;
       }
     }
 
@@ -184,7 +184,7 @@ header {
       @apply fixed bottom-0 left-0 z-40 bg-white w-full px-4 py-3 flex justify-between text-secondary shadow-[0_-4px_6px_rgba(198,198,198,0.25)];
 
       &__trigger {
-        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2;
+        @apply flex items-center text-secondary cursor-pointer justify-evenly gap-x-1 px-2 py-1;
 
         svg {
           @apply w-6 h-6 fill-current;
@@ -206,10 +206,6 @@ header {
 
       &__dropdown {
         @apply absolute top-full left-0 z-30 bg-white;
-      }
-
-      &__dropdown-before {
-        @apply before:block before:absolute before:-top-10 before:right-12 before:content-[""] before:bg-white before:w-24 before:h-12 before:-mt-8;
       }
 
       &__account {
@@ -260,7 +256,7 @@ header {
         }
 
         svg + span {
-          @apply text-sm first-letter:uppercase w-auto;
+          @apply w-auto text-md leading-[22px] first-letter:uppercase font-semibold;
 
           flex-shrink: 0;
         }
@@ -317,14 +313,18 @@ header {
     @apply container h-full flex justify-between items-center lg:relative last-of-type:[&>svg]:hidden;
 
     &__container {
-      @apply bg-primary relative h-14;
+      @apply bg-white relative h-14 flex justify-between;
     }
 
     &__breadcrumb-desktop {
-      @apply hidden lg:flex justify-between items-center gap-2.5 [&>*]:text-lg [&>*]:text-white;
+      @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-black;
+
+      .no-interactive {
+        @apply font-normal px-2;
+      }
 
       &__dropdown-trigger {
-        @apply flex rounded px-2 py-1 z-20;
+        @apply flex rounded py-1 z-20 pr-2 font-semibold;
 
         &:hover {
           @apply z-10 relative before:content-[''] before:absolute before:w-[calc(100%+3rem+1px)] before:min-w-[10rem] before:h-40 before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/4 before:-z-10;
@@ -336,7 +336,7 @@ header {
       }
 
       &__dropdown-wrapper {
-        @apply flex items-center cursor-pointer rounded hover:backdrop-brightness-75 focus:backdrop-brightness-75 focus:outline-none;
+        @apply flex items-center cursor-pointer underline focus:backdrop-brightness-75 focus:outline-none;
       }
 
       &__dropdown-content {
@@ -410,11 +410,15 @@ header {
       @apply block lg:hidden w-full z-20;
 
       &__dropdown-trigger {
-        @apply flex items-center justify-between text-white;
+        @apply flex items-center justify-between text-black;
 
         svg {
           @apply w-6 h-6 fill-current;
         }
+      }
+
+      .menu-bar__breadcrumb-item {
+        @apply font-semibold underline;
       }
 
       /* overwrite default dropdown styles */

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -1,6 +1,6 @@
 header {
   .admin-bar {
-    @apply container flex flex-wrap items-center justify-start gap-y-2 gap-x-4;
+    @apply container flex flex-wrap items-center justify-start gap-y-2 gap-x-4 md:px-0;
 
     &__container {
       @apply bg-tertiary py-2;
@@ -39,7 +39,7 @@ header {
   }
 
   .main-bar {
-    @apply container grid grid-cols-4 md:flex md:justify-between gap-4 items-center py-5 h-24 px-0;
+    @apply container flex justify-between gap-4 items-center py-5 h-24 px-4 md:px-0;
 
     &--focus-mode-back-button {
       @apply h-16 lg:h-24;
@@ -65,15 +65,23 @@ header {
       @apply hidden md:block col-span-2 col-start-5 xl:col-start-4;
 
       form {
-        @apply block relative rounded text-md bg-background;
+        @apply block relative rounded text-md bg-background-6 border border-gray-7 h-full;
       }
 
       input[type="text"] {
-        @apply block bg-transparent w-full px-4 py-1.5;
+        @apply block bg-transparent w-full px-4 py-1.5 h-full;
+
+        &::placeholder {
+          @apply text-gray-8 ltr:pl-6 rtl:pr-6;
+        }
       }
 
       button[type="submit"] {
-        @apply absolute ltr:right-2 rtl:left-2 inset-y-2 text-secondary;
+        @apply absolute ltr:left-4 rtl:right-4 inset-y-2;
+
+        svg {
+          @apply fill-gray-8;
+        }
       }
     }
 
@@ -176,14 +184,23 @@ header {
       @apply fixed bottom-0 left-0 z-40 bg-white w-full px-4 py-3 flex justify-between text-secondary shadow-[0_-4px_6px_rgba(198,198,198,0.25)];
 
       &__trigger {
-        @apply flex flex-col items-center text-secondary cursor-pointer;
+        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2;
 
         svg {
           @apply w-6 h-6 fill-current;
         }
 
         span {
-          @apply text-sm first-letter:uppercase;
+          @apply text-secondary;
+        }
+
+        &:hover {
+          @apply bg-secondary rounded-[4px] text-white;
+
+          svg,
+          span {
+            @apply text-white;
+          }
         }
       }
 
@@ -430,7 +447,7 @@ header {
       @apply absolute top-full left-0 rounded w-full bg-gray-5;
 
       &-desktop {
-        @apply border-r border-gray-6 pr-6;
+        @apply border-r border-gray-6 pr-10;
 
         & button {
           @apply border border-gray-7 rounded px-4 py-2 gap-x-2;
@@ -505,7 +522,7 @@ header {
       @apply bg-white flex flex-row rounded-b shadow-lg text-black w-full lg:w-[530px] h-screen md:h-auto;
 
       &__left {
-        @apply flex flex-col justify-between p-4 md:p-8 space-y-5 hidden md:block md:w-3/4;
+        @apply p-4 md:p-8 space-y-5 hidden md:block md:w-3/4;
 
         &-top {
           @apply border-b-4 border-gray-3 pb-3;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -39,7 +39,7 @@ header {
   }
 
   .main-bar {
-    @apply container grid grid-cols-4 md:grid-cols-8 lg:grid-cols-12 gap-4 items-center py-5 h-24;
+    @apply container grid grid-cols-4 md:flex md:justify-between gap-4 items-center py-5 h-24;
 
     &--focus-mode-back-button {
       @apply h-16 lg:h-24;
@@ -98,7 +98,11 @@ header {
       @apply hidden lg:flex items-center justify-between text-center divide-x-2 divide-gray-3 ml-auto [&>*]:px-4 xl:[&>*]:px-6 first:[&>*]:pl-0 last:[&>*]:pr-0;
 
       &__item {
-        @apply flex flex-col items-center text-secondary px-2 py-1 rounded hover:underline hover:bg-background;
+        @apply flex items-center gap-x-2 text-secondary px-2 py-1 rounded;
+
+        &:hover {
+          @apply bg-secondary rounded-[4px] text-white;
+        }
 
         &-wrapper {
           @apply flex gap-x-4 xl:gap-x-6;
@@ -109,17 +113,62 @@ header {
         }
       }
 
+      &__dropdown {
+        @apply flex items-end absolute top-full right-0 z-30;
+
+        .menu-bar {
+          &__main-dropdown {
+            @apply hidden lg:flex flex-col;
+
+            &__left {
+              @apply w-full;
+            }
+          }
+
+          &__dropdown-menu {
+            @apply w-full;
+
+            li {
+              @apply border-none;
+            }
+          }
+        }
+      }
+
+      &__trigger {
+        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2;
+
+        span {
+          @apply text-secondary;
+        }
+
+        &:hover {
+          @apply bg-secondary rounded-[4px] text-white;
+
+          svg,
+          span {
+            @apply text-white;
+          }
+        }
+
+        &[aria-expended="true"] {
+          #content {
+            @apply bg-[rgb(0_0_0_/_0.5)];
+          }
+        }
+      }
+
       /* overwrite default dropdown styles */
       [data-target*="dropdown"] > span:only-of-type {
         @apply gap-0;
       }
 
       svg {
-        @apply w-5 h-5 fill-current;
+        @apply w-4 h-5 fill-current;
       }
 
       svg + span {
-        @apply text-sm first-letter:uppercase;
+        @apply text-md leading-[22px] first-letter:uppercase;
       }
     }
 
@@ -127,7 +176,7 @@ header {
       @apply fixed bottom-0 left-0 z-40 bg-white w-full px-4 py-3 flex justify-between text-secondary shadow-[0_-4px_6px_rgba(198,198,198,0.25)];
 
       &__trigger {
-        @apply flex flex-col items-center text-secondary cursor-pointer md:pl-4 md:border-l border-gray-3;
+        @apply flex flex-col items-center text-secondary cursor-pointer;
 
         svg {
           @apply w-6 h-6 fill-current;
@@ -239,7 +288,7 @@ header {
 
     /* overwrite default dropdown styles */
     [id*="dropdown-menu"] {
-      @apply py-0 mx-0 w-full;
+      @apply py-0 mx-0 w-full lg:w-fit;
 
       &[aria-hidden="true"] {
         @apply md:hidden;
@@ -382,14 +431,14 @@ header {
     }
 
     &__dropdown-menu {
-      @apply w-full md:w-1/4 bg-primary px-4 md:px-8 pt-0 pb-3 md:py-3 divide-y divide-gray-3 text-white;
+      @apply w-full md:w-1/4 px-4 md:px-8 pt-0 pb-3 md:py-3 divide-y divide-gray-3 text-[var(--secondary)];
 
       > * {
-        @apply py-3 md:py-3.5;
+        @apply py-3 md:py-3.5 md:px-2;
       }
 
       a {
-        @apply flex items-center justify-start gap-1 font-semibold text-lg text-white;
+        @apply flex items-center justify-start gap-1 font-semibold text-xl text-[var(--secondary)] underline;
 
         span {
           @apply min-w-0 truncate;
@@ -399,10 +448,18 @@ header {
           @apply flex-none fill-current;
         }
       }
+
+      li:hover {
+        @apply bg-[var(--secondary)] rounded-[4px];
+
+        a {
+          @apply text-white;
+        }
+      }
     }
 
     &__main-dropdown {
-      @apply bg-white flex flex-row rounded-b shadow-lg text-black w-full lg:w-[1280px] h-screen md:h-auto;
+      @apply bg-white flex flex-row rounded-b shadow-lg text-black w-full lg:w-[530px] h-screen md:h-auto;
 
       &__left {
         @apply flex flex-col justify-between p-4 md:p-8 space-y-5 hidden md:block md:w-3/4;
@@ -459,6 +516,24 @@ header {
 
       &__subtitle {
         @apply hidden text-md md:flex md:text-lg text-gray-2 mt-5;
+      }
+    }
+
+    &__dropdown-desktop {
+      .card__highlight {
+        @apply flex-col ring-transparent rounded-lg shadow-[1px_4px_8px_3px_rgba(0,0,0,0.15)];
+
+        &-img {
+          @apply w-full aspect-[3/1] rounded-tl-lg rounded-tr-lg;
+        }
+
+        &-text {
+          @apply w-full items-start text-start bg-background-2 rounded-bl-lg rounded-br-lg;
+
+          h3 {
+            @apply font-bold;
+          }
+        }
       }
     }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -39,7 +39,7 @@ header {
   }
 
   .main-bar {
-    @apply container grid grid-cols-4 md:flex md:justify-between gap-4 items-center py-5 h-24;
+    @apply container grid grid-cols-4 md:flex md:justify-between gap-4 items-center py-5 h-24 px-0;
 
     &--focus-mode-back-button {
       @apply h-16 lg:h-24;
@@ -427,7 +427,50 @@ header {
     }
 
     &__language-chooser {
-      @apply absolute top-full left-0 bg-white rounded w-full bg-gray-5;
+      @apply absolute top-full left-0 rounded w-full bg-gray-5;
+
+      &-desktop {
+        @apply border-r border-gray-6 pr-6;
+
+        & button {
+          @apply border border-gray-7 rounded px-4 py-2 gap-x-2;
+
+          & > span,
+          & > svg:first-of-type {
+            @apply text-gray-8;
+            @apply block #{!important};
+          }
+
+          & > span {
+            @apply text-sm font-normal;
+          }
+
+          & > svg:last-of-type {
+            @apply text-gray-2  ml-1;
+            @apply block #{!important};
+          }
+        }
+
+        #dropdown-menu-language-chooser {
+          @apply absolute top-full bg-white shadow-[1px_4px_8px_3px_rgba(0,0,0,0.15)] p-2;
+
+          ul {
+            @apply grid grid-cols-3;
+
+            li:hover {
+              @apply rounded;
+            }
+
+            .is-active {
+              @apply bg-[#fc9292] rounded;
+
+              &:hover {
+                @apply bg-[var(--secondary)];
+              }
+            }
+          }
+        }
+      }
     }
 
     &__dropdown-menu {

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -6,7 +6,7 @@
   }
 
   [data-content] {
-    @apply relative flex flex-col flex-1;
+    @apply relative flex flex-col flex-1 border-t-gray-9 border-t;
   }
 }
 

--- a/decidim-core/app/presenters/decidim/breadcrumb_root_menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/breadcrumb_root_menu_item_presenter.rb
@@ -18,7 +18,7 @@ module Decidim
 
     def arrow_link(text, url, args = {})
       link_to url, class: args.with_indifferent_access[:class] do
-        "<span>#{text}</span> #{icon("arrow-right-line")}".html_safe
+        "<span>#{text}</span>".html_safe
       end
     end
   end

--- a/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
@@ -14,6 +14,5 @@
     <nav class="w-full md:w-auto md:ml-auto" role="navigation" aria-label="Social media">
       <%= render partial: "layouts/decidim/footer/main_social_media_links" %>
     </nav>
-    <%= render partial: "layouts/decidim/footer/main_language_chooser" %>
   </div>
 </div>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
@@ -4,19 +4,15 @@
       <%= icon "global-line" %>
       <span><%= t("name", scope: "locale" ) %></span>
       <%= icon "arrow-down-s-line" %>
-      <span class="sr-only">
-        <% available_locales.each do |locale| %>
-          <span lang="<%= locale %>">
-            <%= I18n.with_locale(locale) { t("layouts.decidim.language_chooser.choose_language") } %>
-          </span>
-        <% end %>
+      <span class="sr-only" lang="<%= locale %>">
+        <%= t("layouts.decidim.language_chooser.choose_language") %>
       </span>
     </button>
 
     <div id="dropdown-menu-language-chooser" aria-hidden="true">
       <ul class="main-footer__language" role="menu">
-        <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
-          <li class="text-black text-md hover:bg-secondary hover:text-white transition" role="presentation">
+        <% available_locales.each do |locale| %>
+          <li class="text-black text-md hover:bg-secondary hover:text-white <%= 'is-active' if (I18n.locale.to_s == locale) %>" role="presentation">
             <%= link_to locale_name(locale), decidim.locale_path(locale:), method: :post, role: "menuitem", lang: locale, class: "p-2 w-full block" %>
           </li>
         <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :participatory_space_actions do %>
-  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent") %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent-secondary") %>
 <% end %>
 
 <%= content_for :participatory_space_mobile_actions do %>
-  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent", mobile: true) %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent-secondary", mobile: true) %>
 <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main.html.erb
@@ -18,7 +18,7 @@
       <% elsif current_user&.ephemeral? %>
         <%= render partial: "layouts/decidim/header/close_ephemeral_session" %>
       <% else %>
-        <div class="flex justify-between gap-x-8">
+        <div class="flex md:justify-between md:gap-x-10">
           <div class="main-bar__search">
             <%= render partial: "layouts/decidim/header/main_search" %>
           </div>

--- a/decidim-core/app/views/layouts/decidim/header/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main.html.erb
@@ -19,24 +19,15 @@
         <%= render partial: "layouts/decidim/header/close_ephemeral_session" %>
       <% else %>
         <div class="flex md:justify-between md:gap-x-10">
-          <div class="main-bar__search">
+          <div role="search" class="main-bar__search">
             <%= render partial: "layouts/decidim/header/main_search" %>
           </div>
-          <div class="main-bar__links-desktop md:flex md:gap-x-8">
+          <nav role="navigation" class="main-bar__links-desktop md:flex md:gap-x-8">
             <%= render partial: "layouts/decidim/header/main_links_desktop" %>
-          </div>
+          </nav>
           <div class="main-bar__menu-mobile">
             <%= render partial: "layouts/decidim/header/main_menu_mobile" %>
           </div>
-        <div role="search" class="main-bar__search">
-          <%= render partial: "layouts/decidim/header/main_search" %>
-        </div>
-        <nav role="navigation" class="main-bar__links-desktop">
-          <%= render partial: "layouts/decidim/header/main_links_desktop" %>
-        </nav>
-        <div class="main-bar__menu-mobile">
-          <%= render partial: "layouts/decidim/header/main_menu_mobile" %>
-        </div>
         <%= render partial: "layouts/decidim/header/main_links_mobile_account" if current_user %>
       <% end %>
     </div>

--- a/decidim-core/app/views/layouts/decidim/header/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main.html.erb
@@ -18,6 +18,16 @@
       <% elsif current_user&.ephemeral? %>
         <%= render partial: "layouts/decidim/header/close_ephemeral_session" %>
       <% else %>
+        <div class="flex justify-between gap-x-8">
+          <div class="main-bar__search">
+            <%= render partial: "layouts/decidim/header/main_search" %>
+          </div>
+          <div class="main-bar__links-desktop md:flex md:gap-x-8">
+            <%= render partial: "layouts/decidim/header/main_links_desktop" %>
+          </div>
+          <div class="main-bar__menu-mobile">
+            <%= render partial: "layouts/decidim/header/main_menu_mobile" %>
+          </div>
         <div role="search" class="main-bar__search">
           <%= render partial: "layouts/decidim/header/main_search" %>
         </div>

--- a/decidim-core/app/views/layouts/decidim/header/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main.html.erb
@@ -28,6 +28,7 @@
           <div class="main-bar__menu-mobile">
             <%= render partial: "layouts/decidim/header/main_menu_mobile" %>
           </div>
+        </div>
         <%= render partial: "layouts/decidim/header/main_links_mobile_account" if current_user %>
       <% end %>
     </div>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -1,61 +1,73 @@
-<div>
-  <%= link_to decidim.pages_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.menu.help") do %>
-    <%= icon "question-line" %><span><%= t("decidim.menu.help") %></span>
-  <% end %>
-</div>
-<div class="main-bar__links-desktop__item-wrapper">
+<div class="flex">
   <div>
-    <% if Decidim.module_installed?(:meetings) %>
-      <%= link_to Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.meetings") do %>
-        <%= icon "road-map-line" %><span><%= t("decidim.pages.home.extended.meetings") %></span>
-      <% end %>
+    <%= link_to decidim.pages_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.menu.help") do %>
+      <%= icon "question-line" %><span><%= t("decidim.menu.help") %></span>
     <% end %>
   </div>
-  <div>
-    <%= link_to decidim.last_activities_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.profiles.show.activity") do %>
-      <%= icon "bubble-chart-line" %><span><%= t("decidim.profiles.show.activity") %></span>
-    <% end %>
-  </div>
-</div>
-
-<% if !current_user %>
-  <div>
-    <%= link_to decidim.new_user_session_path, class: "main-bar__links-desktop__item", "aria-label": t("layouts.decidim.header.log_in") do %>
-      <%= icon "user-line" %><span><%= t("layouts.decidim.header.log_in") %></span>
-    <% end %>
-  </div>
-<% else %>
-  <div class="main-bar__dropdown-container">
-    <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account">
-      <% unread_data = current_user_unread_data %>
-      <% if unread_data[:unread_items] %>
-        <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>
-        <% if unread_data[:unread_notifications] %>
-          <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
-        <% end %>
-        <% if unread_data[:unread_conversations] %>
-          <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
+  <div class="main-bar__links-desktop__item-wrapper">
+    <div>
+      <% if Decidim.module_installed?(:meetings) %>
+        <%= link_to Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.meetings") do %>
+          <%= icon "road-map-line" %><span><%= t("decidim.pages.home.extended.meetings") %></span>
         <% end %>
       <% end %>
-      <% if current_user.avatar.attached? %>
-        <span class="main-bar__avatar">
-          <span>
-            <%= image_tag(
-                  current_user.attached_uploader(:avatar).variant_url(:thumb),
-                  alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.avatar.name))
-                ) %>
-          </span>
-        </span>
-      <% else %>
-        <span class="main-bar__links-desktop__item-account">
-          <%= text_initials(current_user.name) %>
-        </span>
+    </div>
+    <div>
+      <%= link_to decidim.last_activities_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.profiles.show.activity") do %>
+        <%= icon "bubble-chart-line" %><span><%= t("decidim.profiles.show.activity") %></span>
       <% end %>
-    </button>
-    <div id="dropdown-menu-account" aria-hidden="true">
-      <ul class="dropdown dropdown__bottom main-bar__dropdown">
-        <%= render partial: "layouts/decidim/header/main_links_dropdown", locals: { unread_data: } %>
-      </ul>
     </div>
   </div>
-<% end %>
+
+  <% if !current_user %>
+    <div>
+      <%= link_to decidim.new_user_session_path, class: "main-bar__links-desktop__item", "aria-label": t("layouts.decidim.header.log_in") do %>
+        <%= icon "user-line" %><span><%= t("layouts.decidim.header.log_in") %></span>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="main-bar__dropdown-container">
+      <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account">
+        <% unread_data = current_user_unread_data %>
+        <% if unread_data[:unread_items] %>
+          <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>
+          <% if unread_data[:unread_notifications] %>
+            <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
+          <% end %>
+          <% if unread_data[:unread_conversations] %>
+            <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
+          <% end %>
+        <% end %>
+        <% if current_user.avatar.attached? %>
+          <span class="main-bar__avatar">
+            <span>
+              <%= image_tag(
+                    current_user.attached_uploader(:avatar).variant_url(:thumb),
+                    alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.avatar.name))
+                  ) %>
+            </span>
+          </span>
+        <% else %>
+          <span class="main-bar__links-desktop__item-account">
+            <%= text_initials(current_user.name) %>
+          </span>
+        <% end %>
+      </button>
+      <div id="dropdown-menu-account" aria-hidden="true">
+        <ul class="dropdown dropdown__bottom main-bar__dropdown">
+          <%= render partial: "layouts/decidim/header/main_links_dropdown", locals: { unread_data: unread_data } %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+  <button id="main-dropdown-summary-desktop" class="main-bar__links-desktop__trigger"
+          data-controller="dropdown"
+          data-target="dropdown-menu-main-desktop">
+    <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
+    <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
+  </button>
+
+  <div id="dropdown-menu-main-desktop" class="main-bar__links-desktop__dropdown main-bar__links-desktop__dropdown-before" aria-hidden="true">
+    <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_desktop", locals: { id: "breadcrumb-main-dropdown-desktop" } %>
+  </div>
+</div>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -1,4 +1,7 @@
-<div class="flex">
+<div class="flex items-center gap-x-8">
+  <div class="menu-bar__language-chooser-desktop">
+    <%= render partial: "layouts/decidim/footer/main_language_chooser"%>
+  </div>
   <% if !current_user %>
     <div>
       <%= link_to decidim.new_user_session_path, class: "main-bar__links-desktop__item", "aria-label": t("layouts.decidim.header.log_in") do %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -1,24 +1,4 @@
 <div class="flex">
-  <div>
-    <%= link_to decidim.pages_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.menu.help") do %>
-      <%= icon "question-line" %><span><%= t("decidim.menu.help") %></span>
-    <% end %>
-  </div>
-  <div class="main-bar__links-desktop__item-wrapper">
-    <div>
-      <% if Decidim.module_installed?(:meetings) %>
-        <%= link_to Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.meetings") do %>
-          <%= icon "road-map-line" %><span><%= t("decidim.pages.home.extended.meetings") %></span>
-        <% end %>
-      <% end %>
-    </div>
-    <div>
-      <%= link_to decidim.last_activities_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.profiles.show.activity") do %>
-        <%= icon "bubble-chart-line" %><span><%= t("decidim.profiles.show.activity") %></span>
-      <% end %>
-    </div>
-  </div>
-
   <% if !current_user %>
     <div>
       <%= link_to decidim.new_user_session_path, class: "main-bar__links-desktop__item", "aria-label": t("layouts.decidim.header.log_in") do %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
@@ -1,8 +1,8 @@
 <button id="main-dropdown-summary-mobile" class="main-bar__links-mobile__trigger p-0"
                                           data-controller="dropdown"
                                           data-target="dropdown-menu-main-mobile">
-  <%= icon "menu-line" %><span class="sr-only"><%= t("main_menu", scope: "layouts.decidim.header") %></span>
-  <%= icon "close-line" %>
+  <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
+  <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
 </button>
 
 <div id="dropdown-menu-main-mobile" class="main-bar__links-mobile__dropdown main-bar__links-mobile__dropdown-before" aria-hidden="true">

--- a/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
@@ -4,6 +4,7 @@
   <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
   <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
 </button>
+<div aria-hidden="true" class="border-r border-gray-6 h-full"></div>
 
 <div id="dropdown-menu-main-mobile" class="main-bar__links-mobile__dropdown main-bar__links-mobile__dropdown-before" aria-hidden="true">
   <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_mobile", locals: { id: "breadcrumb-main-dropdown-mobile" } %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu.html.erb
@@ -2,9 +2,9 @@
   <div class="menu-bar">
 
     <%# secondary dropdown only desktop %>
-    <div class="menu-bar__breadcrumb-desktop">
+    <nav class="menu-bar__breadcrumb-desktop">
       <%= render partial: "layouts/decidim/header/menu_breadcrumb_desktop" %>
-    </div>
+    </nav>
     <% if content_for?(:participatory_space_actions) %>
       <div class="menu-bar__actions">
         <%= content_for :participatory_space_actions %>
@@ -12,9 +12,9 @@
     <% end %>
 
     <%# secondary dropdown mobile-tablet %>
-    <div class="menu-bar__breadcrumb-mobile">
+    <nav class="menu-bar__breadcrumb-mobile">
       <%= render partial: "layouts/decidim/header/menu_breadcrumb_mobile_tablet" %>
-    </div>
+    </nav>
 
   </div>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
@@ -1,14 +1,6 @@
-<div class="menu-bar__breadcrumb-desktop__dropdown-wrapper" onmouseenter="document.getElementById('main-dropdown-menu').classList.remove('no-animation')">
-  <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-desktop__dropdown-trigger", onmouseenter: "document.getElementById('main-dropdown-summary').click()" do %>
-    <%= icon "home-2-line", class: "pointer-events-none" %><span class="sr-only"><%= t("decidim.menu.home") %></span>
+<div class="menu-bar__breadcrumb-desktop__dropdown-wrapper">
+  <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-desktop__dropdown-trigger" do %>
+    <span class=""><%= t("decidim.menu.home") %></span>
   <% end %>
-  <button id="main-dropdown-summary" class="menu-bar__breadcrumb-desktop__dropdown-trigger" data-controller="dropdown" data-hover="true" data-target="main-dropdown-menu">
-    <%= icon "arrow-drop-down-line" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
-  </button>
 </div>
-
-<div id="main-dropdown-menu" class="menu-bar__breadcrumb-desktop__dropdown-content no-animation" aria-hidden="true">
-  <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_desktop", locals: { id: "breadcrumb-main-dropdown-desktop" } %>
-</div>
-
 <%= render partial: "layouts/decidim/header/menu_breadcrumb_items" %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
@@ -2,32 +2,10 @@
   <% next if item.blank? %>
 
   <% item_label = translated_attribute(item[:label]) %>
-  <span>/</span>
-  <% if item[:dropdown_cell].present? %>
-    <div class="relative">
-      <div class="menu-bar__breadcrumb-desktop__dropdown-wrapper" <%== 'aria-current="page"' if item[:active] %> onmouseenter="document.getElementById('secondary-dropdown-menu-<%= i %>').classList.remove('no-animation')">
-        <%= link_to item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-trigger", onmouseenter: "document.getElementById('secondary-dropdown-summary-#{i}').click()" do %>
-          <%= item_label %>
-        <% end %>
-        <button id="secondary-dropdown-summary-<%= i %>"
-          class="menu-bar__breadcrumb-desktop__dropdown-trigger"
-          data-controller="dropdown"
-          data-hover="true"
-          data-target="secondary-dropdown-menu-<%= i %>">
-          <%= icon "arrow-drop-down-line" %>
-          <span class="sr-only"><%= t("layouts.decidim.header.user_menu") %></span>
-        </button>
-      </div>
-
-      <div id="secondary-dropdown-menu-<%= i %>" class="menu-bar__breadcrumb-desktop__dropdown-content-secondary no-animation" aria-hidden="true">
-        <%= cell item[:dropdown_cell], item[:resource] %>
-      </div>
-    </div>
-  <% else %>
-    <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
-      <%# alternative template %>
-      <%= content_tag :span, item_label, class: "menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" if item[:active] %>
-    <% end %>
+  <span aria-hidden="true"><%= icon "arrow-right-s-line" %></span>
+  <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
+    <%# This block is executed if the condition is false %>
+    <%= content_tag :span, item_label, class: "menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" %>
   <% end %>
 <% end %>
 

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_desktop.html.erb
@@ -1,10 +1,6 @@
-<div id="<%= id %>" class="menu-bar__main-dropdown">
-  <div class="menu-bar__main-dropdown__left">
-    <div class="menu-bar__main-dropdown__left-top">
-      <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_top_left" %>
-    </div>
-    <%= cell("decidim/highlighted_participatory_process", menu_highlighted_participatory_process) %>
-    <%= cell "decidim/content_blocks/menu_breadcrumb_last_activity", current_organization %>
-  </div>
+<div id="<%= id %>" class="menu-bar__main-dropdown menu-bar__dropdown-desktop">
   <%= breadcrumb_root_menu.render %>
+  <div class="menu-bar__main-dropdown__left">
+    <%= cell("decidim/highlighted_participatory_process", menu_highlighted_participatory_process) %>
+  </div>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -1,33 +1,25 @@
-<% dropdown_item = breadcrumb_items.select { |item| item[:dropdown_cell].present? }.last %>
+<% previous_item = breadcrumb_items[-2] if breadcrumb_items.size > 1 %>
 <div class="menu-bar__breadcrumb-mobile__dropdown-trigger">
   <span class="inline-block w-full overflow-hidden text-ellipsis align-middle">
-    <% breadcrumb_items.last(2).each_with_index do |item, idx| %>
-      <% item_label = decidim_escape_translated(item[:label]) %>
-      <% if idx.positive? %>
-        <span>/</span>
-      <% end %>
-      <span class="cursor-pointer truncate" <%== 'aria-current="page"' if item[:active] %>>
-        <% if item[:url].present? && !is_active_link?(item[:url], :exclusive) %>
-          <%= link_to(item_label, item[:url]) %>
+      <span class="cursor-pointer truncate flex items-center gap-x-2">
+        <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
+        <% if previous_item %>
+          <% item_label = decidim_escape_translated(previous_item[:label]) %>
+          <% if previous_item[:url].present? && !is_active_link?(previous_item[:url], :exclusive) %>
+            <%= link_to(item_label, previous_item[:url], class: "menu-bar__breadcrumb-item") %>
+          <% else %>
+            <span class="menu-bar__breadcrumb-item"><%= item_label %></span>
+          <% end %>
         <% else %>
-          <%= item_label %>
+          <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-item" do %>
+            <span class=""><%= t("decidim.menu.home") %></span>
+          <% end %>
         <% end %>
       </span>
-    <% end %>
   </span>
-  <% if dropdown_item.present? %>
-    <button id="secondary-dropdown-trigger-mobile" data-controller="dropdown" data-hover="true" data-target="secondary-dropdown-menu-mobile">
-      <%= icon "arrow-down-s-line", class: "flex-none w-6 h-6 fill-current" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
-    </button>
-  <% end %>
   <% if content_for?(:participatory_space_mobile_actions) %>
     <div class="menu-bar__actions-mobile">
       <%= content_for :participatory_space_mobile_actions %>
     </div>
   <% end %>
 </div>
-<% if dropdown_item.present? %>
-  <div id="secondary-dropdown-menu-mobile" aria-hidden="true">
-    <%= cell dropdown_item[:dropdown_cell], dropdown_item[:resource], mobile: true %>
-  </div>
-<% end %>

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -49,7 +49,8 @@ module.exports = {
         5: "#F6F8FA",
         6: "#D3D5D9",
         7: "#D4D4D4",
-        8: "#737373"
+        8: "#737373",
+        9: "#F5F5F5"
       },
       background: {
         DEFAULT: "#F3F4F7",
@@ -64,7 +65,14 @@ module.exports = {
       center: true,
       padding: {
         DEFAULT: "1rem",
-        lg: "4rem"
+        lg: "0"
+      },
+      screens: {
+        sm: '776px',
+        md: '904px',
+        lg: '1160px',
+        xl: '1416px',
+        '2xl': '1672px'
       }
     },
     fontFamily: {

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -47,7 +47,9 @@ module.exports = {
         3: "#E1E5EF",
         4: "#242424",
         5: "#F6F8FA",
-        6: "#D3D5D9"
+        6: "#D3D5D9",
+        7: "#D4D4D4",
+        8: "#737373"
       },
       background: {
         DEFAULT: "#F3F4F7",

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -56,7 +56,8 @@ module.exports = {
         2: "#FAFBFC",
         3: "#EFEFEF",
         4: "#E4EEFF99", // 60% opacity
-        5: "#E9E9E9"
+        5: "#E9E9E9",
+        6: "#FAFAFA"
       }
     },
     container: {

--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -12,7 +12,7 @@ describe "Menu" do
 
   context "when clicking on a menu entry" do
     before do
-      click_on("Help", match: :first)
+      visit decidim.pages_path
     end
 
     it "switches the active option" do

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -112,7 +112,7 @@
 
   &__list-list {
     .card__proposals-item {
-      @apply border-l-4 rounded-[10px] md:rounded-md border-[#F5F5F5] hover:border-tertiary focus-visible:border-tertiary flex flex-col md:items-center md:flex-row md:justify-between min-h-0 md:min-h-[127px] lg:min-h-[83px];
+      @apply border-l-4 rounded-[10px] md:rounded-md border-gray-9 hover:border-tertiary focus-visible:border-tertiary flex flex-col md:items-center md:flex-row md:justify-between min-h-0 md:min-h-[127px] lg:min-h-[83px];
 
       .card__list {
         @apply border-none md:flex-1 md:items-center mb-2.5 md:mb-0;
@@ -128,7 +128,7 @@
 
       .card__proposals-votes,
       .card__proposals-votes-hidden {
-        @apply flex md:flex-col lg:flex-row bg-[#F5F5F5] justify-around md:flex-[0.6] lg:flex-[0.8] items-center md:items-stretch lg:items-center lg:min-w-[196px] h-[68px] md:h-auto lg:h-[68px];
+        @apply flex md:flex-col lg:flex-row bg-gray-9 justify-around md:flex-[0.6] lg:flex-[0.8] items-center md:items-stretch lg:items-center lg:min-w-[196px] h-[68px] md:h-auto lg:h-[68px];
 
         button {
           @apply bg-[var(--secondary)];


### PR DESCRIPTION
#### :tophat: What? Why?
Introduce a hamburger menu for desktop viewports that consolidates navigation items into a collapsible panel. This menu would behave similarly to the mobile version:

- Navigation links are hidden behind a hamburger icon.
- Clicking the icon opens a side panel showing the navigation links.
- The menu closes when the user clicks outside it or clicks the close icon.
[Figma file](https://www.figma.com/design/GIPwk1eZEFBMUs3gcsTRXg/NGI?node-id=487-10360)

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/14937

#### Testing

- Visit the platform on a desktop screen, when the header loads, you should see a hamburger menu icon
- Click the hamburger icon, then a menu panel opens displaying the full list of navigation links.
- Click outside the panel or click close, then the panel closes.
- The menu is closed, then you can open it again using the same icon.
- Navigate through the links inside the hamburger menu, you should be redirected to the corresponding section.

### :camera: Screenshots
![Uploading image.png…]()

:hearts: Thank you!
