### PR TITLE
Add language chooser to header

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -427,7 +427,42 @@ header {
     }
 
     &__language-chooser {
-      @apply absolute top-full left-0 bg-white rounded w-full bg-gray-5;
+      @apply absolute top-full left-0 rounded w-full bg-gray-5;
+
+      &-desktop {
+        @apply border-r border-gray-6 pr-8;
+
+        & button {
+          @apply border border-gray-7 rounded px-4 py-2 gap-x-2;
+
+          & > span,
+          & > svg:first-of-type {
+            @apply text-gray-8;
+            @apply block #{!important};
+          }
+
+          & > span {
+            @apply text-sm font-normal;
+          }
+
+          & > svg:last-of-type {
+            @apply text-gray-2  ml-1;
+            @apply block #{!important};
+          }
+        }
+
+        #dropdown-menu-language-chooser {
+          @apply absolute top-full bg-white shadow-[1px_4px_8px_3px_rgba(0,0,0,0.15)] p-2;
+
+          ul {
+            @apply grid grid-cols-3;
+
+            li:hover {
+              @apply rounded
+            }
+          }
+        }
+      }
     }
 
     &__dropdown-menu {

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -39,7 +39,7 @@ header {
   }
 
   .main-bar {
-    @apply container grid grid-cols-4 md:flex md:justify-between gap-4 items-center py-5 h-24;
+    @apply container grid grid-cols-4 md:flex md:justify-between gap-4 items-center py-5 h-24 px-0;
 
     &--focus-mode-back-button {
       @apply h-16 lg:h-24;
@@ -430,7 +430,7 @@ header {
       @apply absolute top-full left-0 rounded w-full bg-gray-5;
 
       &-desktop {
-        @apply border-r border-gray-6 pr-8;
+        @apply border-r border-gray-6 pr-6;
 
         & button {
           @apply border border-gray-7 rounded px-4 py-2 gap-x-2;
@@ -458,7 +458,15 @@ header {
             @apply grid grid-cols-3;
 
             li:hover {
-              @apply rounded
+              @apply rounded;
+            }
+
+            .is-active {
+              @apply bg-[#fc9292] rounded;
+
+              &:hover {
+                @apply bg-[var(--secondary)];
+              }
             }
           }
         }

--- a/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
@@ -11,8 +11,8 @@
 
     <div id="dropdown-menu-language-chooser" aria-hidden="true">
       <ul class="main-footer__language" role="menu">
-        <% (available_locales - [I18n.locale.to_s]).sort.each do |locale| %>
-          <li class="text-black text-md hover:bg-secondary hover:text-white" role="presentation">
+        <% available_locales.each do |locale| %>
+          <li class="text-black text-md hover:bg-secondary hover:text-white <%= 'is-active' if (I18n.locale.to_s == locale) %>" role="presentation">
             <%= link_to locale_name(locale), decidim.locale_path(locale:), method: :post, role: "menuitem", lang: locale, class: "p-2 w-full block" %>
           </li>
         <% end %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
@@ -4,19 +4,15 @@
       <%= icon "global-line" %>
       <span><%= t("name", scope: "locale" ) %></span>
       <%= icon "arrow-down-s-line" %>
-      <span class="sr-only">
-        <% available_locales.each do |locale| %>
-          <span lang="<%= locale %>">
-            <%= I18n.with_locale(locale) { t("layouts.decidim.language_chooser.choose_language") } %>
-          </span>
-        <% end %>
+      <span class="sr-only" lang="<%= locale %>">
+        <%= t("layouts.decidim.language_chooser.choose_language") %>
       </span>
     </button>
 
     <div id="dropdown-menu-language-chooser" aria-hidden="true">
       <ul class="main-footer__language" role="menu">
-        <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
-          <li class="text-black text-md hover:bg-secondary hover:text-white transition" role="presentation">
+        <% (available_locales - [I18n.locale.to_s]).sort.each do |locale| %>
+          <li class="text-black text-md hover:bg-secondary hover:text-white" role="presentation">
             <%= link_to locale_name(locale), decidim.locale_path(locale:), method: :post, role: "menuitem", lang: locale, class: "p-2 w-full block" %>
           </li>
         <% end %>

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -47,7 +47,9 @@ module.exports = {
         3: "#E1E5EF",
         4: "#242424",
         5: "#F6F8FA",
-        6: "#D3D5D9"
+        6: "#D3D5D9",
+        7: "#D4D4D4",
+        8: "#737373"
       },
       background: {
         DEFAULT: "#F3F4F7",


### PR DESCRIPTION
#### :tophat: What? Why?
Added a language selector to the header, visible on all pages of the platform. On desktop, it should appear as a dropdown menu with the list of available locales. On mobile, it should be accessible from the hamburger menu.
https://www.figma.com/design/GIPwk1eZEFBMUs3gcsTRXg/NGI?node-id=322-34498&t=J1kSIm4IGqHBLfOD-0

#### :pushpin: Related Issues

- Related to (#14212 ps://github.com/decidim/decidim/issues/14936)](https://github.com/decidim/decidim/issues/14936)

#### Testing

1. When you view the site header on desktop, you see a language selector as a dropdown with all available languages.
2. On mobile, when you open the hamburger menu, you see the language selector inside the menu.
3. When you switch languages from the header, the interface language updates immediately and persists across pages.


### :camera: Screenshots
<img width="1116" height="798" alt="image" src="https://github.com/user-attachments/assets/bfe3dd3f-9344-4eca-aa93-e68cafdfe211" />

:hearts: Thank you!