### PR TITLE
Implement breadcrumb navigation

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/sticky_header/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/sticky_header/controller.js
@@ -41,7 +41,7 @@ export default class extends Controller {
     const menuBarContainer = document.querySelector("#menu-bar-container");
 
     // Calculate margin based on screen size and sticky header height
-    const marginTop = this.isMaxScreenSize("md")
+    const marginTop = this.isMaxScreenSize("sm")
       ? this.element.offsetHeight
       : 0;
 

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -21,6 +21,7 @@ const menuContainer = document.getElementById("dropdown-menu-main-desktop");
 const menuButton = document.getElementById("main-dropdown-summary-desktop");
 const content = document.getElementById("content");
 const footer = document.querySelector("footer");
+const menuBar = document.querySelector("#menu-bar-container");
 
 
 menuButton.addEventListener("click", function () {
@@ -30,10 +31,12 @@ menuButton.addEventListener("click", function () {
     menuContainer.setAttribute("aria-hidden", "false");
     content.style.opacity = "0.3";
     footer.style.opacity = "0.3";
+    menuBar.style.opacity = "0.3";
   } else {
     menuContainer.setAttribute("aria-hidden", "true");
     content.style.opacity = "1";
     footer.style.opacity = "1";
+    menuBar.style.opacity = "1";
   }
 });
 

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -44,6 +44,12 @@
   }
 }
 
+[data-target="dropdown-menu-main-desktop"] {
+  > span:first-of-type {
+    @apply block
+  }
+}
+
 [data-target="dropdown-menu-participatory-space"],
 [data-target="dropdown-menu-order"],
 [data-target="dropdown-menu-resource"],

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -1,6 +1,6 @@
 header {
   .admin-bar {
-    @apply container flex flex-wrap items-center justify-start gap-y-2 gap-x-4 md:px-0;
+    @apply container flex flex-wrap items-center justify-start gap-y-2 gap-x-4;
 
     &__container {
       @apply bg-tertiary py-2;
@@ -39,14 +39,14 @@ header {
   }
 
   .main-bar {
-    @apply container flex justify-between gap-4 items-center py-5 h-24 px-4 md:px-0;
+    @apply container flex justify-between gap-4 items-center py-5 h-20;
 
     &--focus-mode-back-button {
       @apply h-16 lg:h-24;
     }
 
     &__container {
-      @apply relative w-full;
+      @apply relative w-full flex justify-between;
     }
 
     &__logo {
@@ -69,10 +69,10 @@ header {
       }
 
       input[type="text"] {
-        @apply block bg-transparent w-full px-4 py-1.5 h-full;
+        @apply block bg-transparent w-full px-4 py-2 h-full;
 
         &::placeholder {
-          @apply text-gray-8 ltr:pl-6 rtl:pr-6;
+          @apply text-gray-8 text-sm ltr:pl-6 rtl:pr-6;
         }
       }
 
@@ -310,21 +310,21 @@ header {
   }
 
   .menu-bar {
-    @apply container h-full flex justify-between items-center lg:relative last-of-type:[&>svg]:hidden md:px-0;
+    @apply container h-full flex justify-between items-center lg:relative last-of-type:[&>svg]:hidden;
 
     &__container {
-      @apply bg-white relative h-14;
+      @apply bg-white relative h-14 flex justify-between;
     }
 
     &__breadcrumb-desktop {
       @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-black;
 
       .no-interactive {
-        @apply font-normal;
+        @apply font-normal px-2;
       }
 
       &__dropdown-trigger {
-        @apply flex rounded px-2 py-1 z-20 font-semibold;
+        @apply flex rounded py-1 z-20 pr-2 font-semibold;
 
         &:hover {
           @apply z-10 relative before:content-[''] before:absolute before:w-[calc(100%+3rem+1px)] before:min-w-[10rem] before:h-40 before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/4 before:-z-10;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -184,7 +184,7 @@ header {
       @apply fixed bottom-0 left-0 z-40 bg-white w-full px-4 py-3 flex justify-between text-secondary shadow-[0_-4px_6px_rgba(198,198,198,0.25)];
 
       &__trigger {
-        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2;
+        @apply flex flex-col items-center text-secondary cursor-pointer;
 
         svg {
           @apply w-6 h-6 fill-current;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -94,7 +94,7 @@ header {
     }
 
     &__menu-mobile {
-      @apply lg:hidden flex flex-row-reverse items-center;
+      @apply lg:hidden flex flex-row-reverse items-center gap-x-3;
     }
 
     &__links-desktop,
@@ -176,7 +176,7 @@ header {
       }
 
       svg + span {
-        @apply text-md leading-[22px] first-letter:uppercase;
+        @apply text-md leading-[22px] first-letter:uppercase font-semibold;
       }
     }
 
@@ -184,7 +184,7 @@ header {
       @apply fixed bottom-0 left-0 z-40 bg-white w-full px-4 py-3 flex justify-between text-secondary shadow-[0_-4px_6px_rgba(198,198,198,0.25)];
 
       &__trigger {
-        @apply flex flex-col items-center text-secondary cursor-pointer;
+        @apply flex items-center text-secondary cursor-pointer justify-evenly gap-x-1 px-2 py-1;
 
         svg {
           @apply w-6 h-6 fill-current;
@@ -206,10 +206,6 @@ header {
 
       &__dropdown {
         @apply absolute top-full left-0 z-30 bg-white;
-      }
-
-      &__dropdown-before {
-        @apply before:block before:absolute before:-top-10 before:right-12 before:content-[""] before:bg-white before:w-24 before:h-12 before:-mt-8;
       }
 
       &__account {
@@ -260,7 +256,7 @@ header {
         }
 
         svg + span {
-          @apply text-sm first-letter:uppercase w-auto;
+          @apply w-auto text-md leading-[22px] first-letter:uppercase font-semibold;
 
           flex-shrink: 0;
         }

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -35,7 +35,7 @@ header {
   }
 
   #sticky-header-container {
-    @apply fixed w-full top-0 shadow-lg z-40 bg-white md:relative transition-top duration-300;
+    @apply fixed w-full top-0 z-40 bg-white md:relative transition-top duration-300;
   }
 
   .main-bar {
@@ -314,17 +314,21 @@ header {
   }
 
   .menu-bar {
-    @apply container h-full flex justify-between items-center lg:relative last-of-type:[&>svg]:hidden;
+    @apply container h-full flex justify-between items-center lg:relative last-of-type:[&>svg]:hidden md:px-0;
 
     &__container {
-      @apply bg-primary relative h-14;
+      @apply bg-white relative h-14;
     }
 
     &__breadcrumb-desktop {
-      @apply hidden lg:flex justify-between items-center gap-2.5 [&>*]:text-lg [&>*]:text-white;
+      @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-black;
+
+      .no-interactive {
+        @apply font-normal;
+      }
 
       &__dropdown-trigger {
-        @apply flex rounded px-2 py-1 z-20;
+        @apply flex rounded px-2 py-1 z-20 font-semibold;
 
         &:hover {
           @apply z-10 relative before:content-[''] before:absolute before:w-[calc(100%+3rem+1px)] before:min-w-[10rem] before:h-40 before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/4 before:-z-10;
@@ -336,7 +340,7 @@ header {
       }
 
       &__dropdown-wrapper {
-        @apply flex items-center cursor-pointer rounded hover:backdrop-brightness-75 focus:backdrop-brightness-75 focus:outline-none;
+        @apply flex items-center cursor-pointer underline focus:backdrop-brightness-75 focus:outline-none;
       }
 
       &__dropdown-content {
@@ -410,11 +414,15 @@ header {
       @apply block lg:hidden w-full z-20;
 
       &__dropdown-trigger {
-        @apply flex items-center justify-between text-white;
+        @apply flex items-center justify-between text-black;
 
         svg {
           @apply w-6 h-6 fill-current;
         }
+      }
+
+      .menu-bar__breadcrumb-item {
+        @apply font-semibold underline;
       }
 
       /* overwrite default dropdown styles */

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -6,7 +6,7 @@
   }
 
   [data-content] {
-    @apply relative flex flex-col flex-1;
+    @apply relative flex flex-col flex-1 border-t-gray-9 border-t;
   }
 }
 

--- a/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
@@ -14,6 +14,5 @@
     <nav class="w-full md:w-auto md:ml-auto" role="navigation" aria-label="Social media">
       <%= render partial: "layouts/decidim/footer/main_social_media_links" %>
     </nav>
-    <%= render partial: "layouts/decidim/footer/main_language_chooser" %>
   </div>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :participatory_space_actions do %>
-  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent") %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent-secondary") %>
 <% end %>
 
 <%= content_for :participatory_space_mobile_actions do %>
-  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent", mobile: true) %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent-secondary", mobile: true) %>
 <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
@@ -4,6 +4,7 @@
   <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
   <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
 </button>
+<div aria-hidden="true" class="border-r border-gray-6 h-full"></div>
 
 <div id="dropdown-menu-main-mobile" class="main-bar__links-mobile__dropdown main-bar__links-mobile__dropdown-before" aria-hidden="true">
   <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_mobile", locals: { id: "breadcrumb-main-dropdown-mobile" } %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu.html.erb
@@ -2,9 +2,9 @@
   <div class="menu-bar">
 
     <%# secondary dropdown only desktop %>
-    <div class="menu-bar__breadcrumb-desktop">
+    <nav class="menu-bar__breadcrumb-desktop">
       <%= render partial: "layouts/decidim/header/menu_breadcrumb_desktop" %>
-    </div>
+    </nav>
     <% if content_for?(:participatory_space_actions) %>
       <div class="menu-bar__actions">
         <%= content_for :participatory_space_actions %>
@@ -12,9 +12,9 @@
     <% end %>
 
     <%# secondary dropdown mobile-tablet %>
-    <div class="menu-bar__breadcrumb-mobile">
+    <nav class="menu-bar__breadcrumb-mobile">
       <%= render partial: "layouts/decidim/header/menu_breadcrumb_mobile_tablet" %>
-    </div>
+    </nav>
 
   </div>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
@@ -1,14 +1,6 @@
-<div class="menu-bar__breadcrumb-desktop__dropdown-wrapper" onmouseenter="document.getElementById('main-dropdown-menu').classList.remove('no-animation')">
-  <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-desktop__dropdown-trigger", onmouseenter: "document.getElementById('main-dropdown-summary').click()" do %>
-    <%= icon "home-2-line", class: "pointer-events-none" %><span class="sr-only"><%= t("decidim.menu.home") %></span>
+<div class="menu-bar__breadcrumb-desktop__dropdown-wrapper">
+  <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-desktop__dropdown-trigger" do %>
+    <span class=""><%= t("decidim.menu.home") %></span>
   <% end %>
-  <button id="main-dropdown-summary" class="menu-bar__breadcrumb-desktop__dropdown-trigger" data-controller="dropdown" data-hover="true" data-target="main-dropdown-menu">
-    <%= icon "arrow-drop-down-line" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
-  </button>
 </div>
-
-<div id="main-dropdown-menu" class="menu-bar__breadcrumb-desktop__dropdown-content no-animation" aria-hidden="true">
-  <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_desktop", locals: { id: "breadcrumb-main-dropdown-desktop" } %>
-</div>
-
 <%= render partial: "layouts/decidim/header/menu_breadcrumb_items" %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
@@ -2,32 +2,10 @@
   <% next if item.blank? %>
 
   <% item_label = translated_attribute(item[:label]) %>
-  <span>/</span>
-  <% if item[:dropdown_cell].present? %>
-    <div class="relative">
-      <div class="menu-bar__breadcrumb-desktop__dropdown-wrapper" <%== 'aria-current="page"' if item[:active] %> onmouseenter="document.getElementById('secondary-dropdown-menu-<%= i %>').classList.remove('no-animation')">
-        <%= link_to item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-trigger", onmouseenter: "document.getElementById('secondary-dropdown-summary-#{i}').click()" do %>
-          <%= item_label %>
-        <% end %>
-        <button id="secondary-dropdown-summary-<%= i %>"
-          class="menu-bar__breadcrumb-desktop__dropdown-trigger"
-          data-controller="dropdown"
-          data-hover="true"
-          data-target="secondary-dropdown-menu-<%= i %>">
-          <%= icon "arrow-drop-down-line" %>
-          <span class="sr-only"><%= t("layouts.decidim.header.user_menu") %></span>
-        </button>
-      </div>
-
-      <div id="secondary-dropdown-menu-<%= i %>" class="menu-bar__breadcrumb-desktop__dropdown-content-secondary no-animation" aria-hidden="true">
-        <%= cell item[:dropdown_cell], item[:resource] %>
-      </div>
-    </div>
-  <% else %>
-    <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
-      <%# alternative template %>
-      <%= content_tag :span, item_label, class: "menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" if item[:active] %>
-    <% end %>
+  <span aria-hidden="true"><%= icon "arrow-right-s-line" %></span>
+  <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
+    <%# This block is executed if the condition is false %>
+    <%= content_tag :span, item_label, class: "menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" %>
   <% end %>
 <% end %>
 

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -1,33 +1,25 @@
-<% dropdown_item = breadcrumb_items.select { |item| item[:dropdown_cell].present? }.last %>
+<% previous_item = breadcrumb_items[-2] if breadcrumb_items.size > 1 %>
 <div class="menu-bar__breadcrumb-mobile__dropdown-trigger">
   <span class="inline-block w-full overflow-hidden text-ellipsis align-middle">
-    <% breadcrumb_items.last(2).each_with_index do |item, idx| %>
-      <% item_label = decidim_escape_translated(item[:label]) %>
-      <% if idx.positive? %>
-        <span>/</span>
-      <% end %>
-      <span class="cursor-pointer truncate" <%== 'aria-current="page"' if item[:active] %>>
-        <% if item[:url].present? && !is_active_link?(item[:url], :exclusive) %>
-          <%= link_to(item_label, item[:url]) %>
+      <span class="cursor-pointer truncate flex items-center gap-x-2">
+        <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
+        <% if previous_item %>
+          <% item_label = decidim_escape_translated(previous_item[:label]) %>
+          <% if previous_item[:url].present? && !is_active_link?(previous_item[:url], :exclusive) %>
+            <%= link_to(item_label, previous_item[:url], class: "menu-bar__breadcrumb-item") %>
+          <% else %>
+            <span class="menu-bar__breadcrumb-item"><%= item_label %></span>
+          <% end %>
         <% else %>
-          <%= item_label %>
+          <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-item" do %>
+            <span class=""><%= t("decidim.menu.home") %></span>
+          <% end %>
         <% end %>
       </span>
-    <% end %>
   </span>
-  <% if dropdown_item.present? %>
-    <button id="secondary-dropdown-trigger-mobile" data-controller="dropdown" data-hover="true" data-target="secondary-dropdown-menu-mobile">
-      <%= icon "arrow-down-s-line", class: "flex-none w-6 h-6 fill-current" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
-    </button>
-  <% end %>
   <% if content_for?(:participatory_space_mobile_actions) %>
     <div class="menu-bar__actions-mobile">
       <%= content_for :participatory_space_mobile_actions %>
     </div>
   <% end %>
 </div>
-<% if dropdown_item.present? %>
-  <div id="secondary-dropdown-menu-mobile" aria-hidden="true">
-    <%= cell dropdown_item[:dropdown_cell], dropdown_item[:resource], mobile: true %>
-  </div>
-<% end %>

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -49,7 +49,8 @@ module.exports = {
         5: "#F6F8FA",
         6: "#D3D5D9",
         7: "#D4D4D4",
-        8: "#737373"
+        8: "#737373",
+        9: "#F5F5F5"
       },
       background: {
         DEFAULT: "#F3F4F7",
@@ -64,7 +65,14 @@ module.exports = {
       center: true,
       padding: {
         DEFAULT: "1rem",
-        lg: "4rem"
+        lg: "0"
+      },
+      screens: {
+        sm: '776px',
+        md: '904px',
+        lg: '1160px',
+        xl: '1416px',
+        '2xl': '1672px'
       }
     },
     fontFamily: {

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -112,7 +112,7 @@
 
   &__list-list {
     .card__proposals-item {
-      @apply border-l-4 rounded-[10px] md:rounded-md border-[#F5F5F5] hover:border-tertiary focus-visible:border-tertiary flex flex-col md:items-center md:flex-row md:justify-between min-h-0 md:min-h-[127px] lg:min-h-[83px];
+      @apply border-l-4 rounded-[10px] md:rounded-md border-gray-9 hover:border-tertiary focus-visible:border-tertiary flex flex-col md:items-center md:flex-row md:justify-between min-h-0 md:min-h-[127px] lg:min-h-[83px];
 
       .card__list {
         @apply border-none md:flex-1 md:items-center mb-2.5 md:mb-0;
@@ -128,7 +128,7 @@
 
       .card__proposals-votes,
       .card__proposals-votes-hidden {
-        @apply flex md:flex-col lg:flex-row bg-[#F5F5F5] justify-around md:flex-[0.6] lg:flex-[0.8] items-center md:items-stretch lg:items-center lg:min-w-[196px] h-[68px] md:h-auto lg:h-[68px];
+        @apply flex md:flex-col lg:flex-row bg-gray-9 justify-around md:flex-[0.6] lg:flex-[0.8] items-center md:items-stretch lg:items-center lg:min-w-[196px] h-[68px] md:h-auto lg:h-[68px];
 
         button {
           @apply bg-[var(--secondary)];


### PR DESCRIPTION
#### :tophat: What? Why?
Implement a dedicated breadcrumb navigation system with the following behavior:

On desktop:

The full breadcrumb is displayed directly below the main header.
It reflects the full hierarchical structure: Organization > Space (e.g., Process or Assembly) > Component > Resource (e.g., proposal, meeting).
Each item is clickable and allows users to go back to that level.

On mobile:

A compact breadcrumb is shown, displaying only the immediately previous item in the navigation hierarchy.
Tapping this item takes the user back to the previous level (e.g., from proposal to component, from component to process).

#### :pushpin: Related Issues
- Related to (https://github.com/decidim/decidim/issues/14938)


#### Testing

- On desktop, when you navigate through a participatory space, then you see a breadcrumb showing the full path from the homepage to the current page.
- You click on any item in the breadcrumb on desktop, then you are redirected to that corresponding level.
- On mobile, when you navigate through a participatory space, then you see a compact breadcrumb showing only the immediate previous level.
- Tap the compact breadcrumb on mobile, then you redirected to the previous level in the hierarchy.

### :camera: Screenshots
<img width="1483" height="700" alt="image" src="https://github.com/user-attachments/assets/4ec93bd6-92c8-4f78-ac1a-d779a5131880" />
<img width="524" height="747" alt="image" src="https://github.com/user-attachments/assets/70dc934d-842e-4876-b1b7-e48feeece686" />


:hearts: Thank you!
