### PR TITLE
Extract Manifests to Configuration Module

### DIFF
--- a/decidim-core/lib/decidim/configuration/component_registry.rb
+++ b/decidim-core/lib/decidim/configuration/component_registry.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Configuration
+    module ComponentRegistry
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Public: Registers a component, usually held in an external library or in a
+        # separate folder in the main repository. Exposes a DSL defined by
+        # `Decidim::ComponentManifest`.
+        #
+        # Component manifests are held in a global registry and are used in all kinds of
+        # places to figure out what new components or functionalities the component provides.
+        #
+        # name - A Symbol with the component's unique name.
+        #
+        # Returns nothing.
+        def register_component(name, &)
+          component_registry.register(name, &)
+        end
+
+        # Public: Stores the registry of components
+        def component_registry
+          @component_registry ||= ManifestRegistry.new(:components)
+        end
+
+        # Public: Finds a component manifest by the component's name.
+        #
+        # name - The name of the ComponentManifest to find.
+        #
+        # Returns a ComponentManifest if found, nil otherwise.
+        def find_component_manifest(name)
+          component_registry.find(name.to_sym)
+        end
+
+        # Public: Finds all registered component manifest's via the `register_component`
+        # method.
+        #
+        # Returns an Array[ComponentManifest].
+        def component_manifests
+          component_registry.manifests.sort_by(&:name)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/configuration/global_engine_registry.rb
+++ b/decidim-core/lib/decidim/configuration/global_engine_registry.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Configuration
+    module GlobalEngineRegistry
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Public: Registers a global engine. This method is intended to be used
+        # by component engines that also offer unscoped functionality
+        #
+        # name    - The name of the engine to register. Should be unique.
+        # engine  - The engine to register.
+        # options - Options to pass to the engine.
+        #           :at - The route to mount the engine to.
+        #
+        # Returns nothing.
+        def register_global_engine(name, engine, options = {})
+          return if global_engines.has_key?(name)
+
+          options[:at] ||= "/#{name}"
+
+          global_engines[name.to_sym] = {
+            at: options[:at],
+            engine:
+          }
+        end
+
+        # Semiprivate: Removes a global engine from the registry. Mostly used on testing,
+        # no real reason to use this on production.
+        #
+        # name - The name of the global engine to remove.
+        #
+        # Returns nothing.
+        def unregister_global_engine(name)
+          global_engines.delete(name.to_sym)
+        end
+
+        # Public: Finds all registered engines via the 'register_global_engine' method.
+        #
+        # Returns an Array[::Rails::Engine]
+        def global_engines
+          @global_engines ||= {}
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/configuration/notification_settings_registry.rb
+++ b/decidim-core/lib/decidim/configuration/notification_settings_registry.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Configuration
+    module NotificationSettingsRegistry
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Public: Registers a notification setting.
+        #
+        # Returns nothing.
+        def notification_settings(name, &)
+          notification_settings_registry.register(name, &)
+        end
+
+        # Public: Stores the registry of notifications settings
+        def notification_settings_registry
+          @notification_settings_registry ||= ManifestRegistry.new(:notification_settings)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/configuration/participatory_space_registry.rb
+++ b/decidim-core/lib/decidim/configuration/participatory_space_registry.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Configuration
+    module ParticipatorySpaceRegistry
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Public: Registers a participatory space, usually held in an external library
+        # or in a separate folder in the main repository. Exposes a DSL defined by
+        # `Decidim::ParticipatorySpaceManifest`.
+        #
+        # Participatory space manifests are held in a global registry and are used in
+        # all kinds of places to figure out what new components or functionalities the
+        # participatory space provides.
+        #
+        # name - A Symbol with the participatory space's unique name.
+        #
+        # Returns nothing.
+        def register_participatory_space(name, &)
+          participatory_space_registry.register(name, &)
+        end
+
+        # Public: Finds a participatory space manifest by the participatory space's
+        # name.
+        #
+        # name - The name of the ParticipatorySpaceManifest to find.
+        #
+        # Returns a ParticipatorySpaceManifest if found, nil otherwise.
+        def find_participatory_space_manifest(name)
+          participatory_space_registry.find(name.to_sym)
+        end
+
+        # Public: Stores the registry of participatory spaces
+        def participatory_space_registry
+          @participatory_space_registry ||= ManifestRegistry.new(:participatory_spaces)
+        end
+
+        # Public: Finds all registered participatory space manifest's via the
+        # `register_participatory_space` method.
+        #
+        # Returns an Array[ParticipatorySpaceManifest].
+        def participatory_space_manifests
+          participatory_space_registry.manifests
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/configuration/resource_registry.rb
+++ b/decidim-core/lib/decidim/configuration/resource_registry.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Configuration
+    module ResourceRegistry
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Public: Registers a resource.
+        #
+        # Returns nothing.
+        def register_resource(name, &)
+          resource_registry.register(name, &)
+        end
+
+        # Public: Finds a resource manifest by the resource's name.
+        #
+        # resource_name_or_class - The String of the ResourceManifest name or the class of
+        # the ResourceManifest model_class to find.
+        #
+        # Returns a ResourceManifest if found, nil otherwise.
+        def find_resource_manifest(resource_name_or_klass)
+          resource_registry.find(resource_name_or_klass)
+        end
+
+        # Public: Stores the registry of resource spaces
+        def resource_registry
+          @resource_registry ||= ManifestRegistry.new(:resources)
+        end
+
+        # Public: Finds all registered resource manifests via the `register_component`
+        # method.
+        #
+        # Returns an Array[ResourceManifest].
+        def resource_manifests
+          resource_registry.manifests
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/configuration/social_share_services_registry.rb
+++ b/decidim-core/lib/decidim/configuration/social_share_services_registry.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Configuration
+    module SocialShareServicesRegistry
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        # Public: Registers a social share service.
+        #
+        # Returns nothing.
+        def register_social_share_service(name, &)
+          social_share_services_registry.register(name, &)
+        end
+
+        # Public: Stores the registry of social shares services
+        def social_share_services_registry
+          @social_share_services_registry ||= ManifestRegistry.new(:social_share_services)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -145,6 +145,22 @@ module Decidim
     autoload :RestoreResource, "decidim/commands/restore_resource"
   end
 
+  module Configuration
+    autoload :ParticipatorySpaceRegistry, "decidim/configuration/participatory_space_registry"
+    autoload :ComponentRegistry, "decidim/configuration/component_registry"
+    autoload :GlobalEngineRegistry, "decidim/configuration/global_engine_registry"
+    autoload :ResourceRegistry, "decidim/configuration/resource_registry"
+    autoload :NotificationSettingsRegistry, "decidim/configuration/notification_settings_registry"
+    autoload :SocialShareServicesRegistry, "decidim/configuration/social_share_services_registry"
+  end
+
+  include Decidim::Configuration::ParticipatorySpaceRegistry
+  include Decidim::Configuration::ComponentRegistry
+  include Decidim::Configuration::ResourceRegistry
+  include Decidim::Configuration::GlobalEngineRegistry
+  include Decidim::Configuration::NotificationSettingsRegistry
+  include Decidim::Configuration::SocialShareServicesRegistry
+
   include ActiveSupport::Configurable
   # Loads seeds from all engines.
   def self.seed!
@@ -791,174 +807,9 @@ module Decidim
     ]
   end
 
-  # Public: Registers a global engine. This method is intended to be used
-  # by component engines that also offer unscoped functionality
-  #
-  # name    - The name of the engine to register. Should be unique.
-  # engine  - The engine to register.
-  # options - Options to pass to the engine.
-  #           :at - The route to mount the engine to.
-  #
-  # Returns nothing.
-  def self.register_global_engine(name, engine, options = {})
-    return if global_engines.has_key?(name)
-
-    options[:at] ||= "/#{name}"
-
-    global_engines[name.to_sym] = {
-      at: options[:at],
-      engine:
-    }
-  end
-
-  # Semiprivate: Removes a global engine from the registry. Mostly used on testing,
-  # no real reason to use this on production.
-  #
-  # name - The name of the global engine to remove.
-  #
-  # Returns nothing.
-  def self.unregister_global_engine(name)
-    global_engines.delete(name.to_sym)
-  end
-
-  # Public: Finds all registered engines via the 'register_global_engine' method.
-  #
-  # Returns an Array[::Rails::Engine]
-  def self.global_engines
-    @global_engines ||= {}
-  end
-
-  # Public: Registers a component, usually held in an external library or in a
-  # separate folder in the main repository. Exposes a DSL defined by
-  # `Decidim::ComponentManifest`.
-  #
-  # Component manifests are held in a global registry and are used in all kinds of
-  # places to figure out what new components or functionalities the component provides.
-  #
-  # name - A Symbol with the component's unique name.
-  #
-  # Returns nothing.
-  def self.register_component(name, &)
-    component_registry.register(name, &)
-  end
-
-  # Public: Registers a participatory space, usually held in an external library
-  # or in a separate folder in the main repository. Exposes a DSL defined by
-  # `Decidim::ParticipatorySpaceManifest`.
-  #
-  # Participatory space manifests are held in a global registry and are used in
-  # all kinds of places to figure out what new components or functionalities the
-  # participatory space provides.
-  #
-  # name - A Symbol with the participatory space's unique name.
-  #
-  # Returns nothing.
-  def self.register_participatory_space(name, &)
-    participatory_space_registry.register(name, &)
-  end
-
-  # Public: Registers a resource.
-  #
-  # Returns nothing.
-  def self.register_resource(name, &)
-    resource_registry.register(name, &)
-  end
-
-  # Public: Registers a social share service.
-  #
-  # Returns nothing.
-  def self.register_social_share_service(name, &)
-    social_share_services_registry.register(name, &)
-  end
-
-  # Public: Registers a notification setting.
-  #
-  # Returns nothing.
-  def self.notification_settings(name, &)
-    notification_settings_registry.register(name, &)
-  end
-
-  # Public: Finds all registered resource manifests via the `register_component`
-  # method.
-  #
-  # Returns an Array[ResourceManifest].
-  def self.resource_manifests
-    resource_registry.manifests
-  end
-
-  # Public: Finds all registered component manifest's via the `register_component`
-  # method.
-  #
-  # Returns an Array[ComponentManifest].
-  def self.component_manifests
-    component_registry.manifests.sort_by(&:name)
-  end
-
-  # Public: Finds all registered participatory space manifest's via the
-  # `register_participatory_space` method.
-  #
-  # Returns an Array[ParticipatorySpaceManifest].
-  def self.participatory_space_manifests
-    participatory_space_registry.manifests
-  end
-
-  # Public: Finds a component manifest by the component's name.
-  #
-  # name - The name of the ComponentManifest to find.
-  #
-  # Returns a ComponentManifest if found, nil otherwise.
-  def self.find_component_manifest(name)
-    component_registry.find(name.to_sym)
-  end
-
-  # Public: Finds a participatory space manifest by the participatory space's
-  # name.
-  #
-  # name - The name of the ParticipatorySpaceManifest to find.
-  #
-  # Returns a ParticipatorySpaceManifest if found, nil otherwise.
-  def self.find_participatory_space_manifest(name)
-    participatory_space_registry.find(name.to_sym)
-  end
-
-  # Public: Finds a resource manifest by the resource's name.
-  #
-  # resource_name_or_class - The String of the ResourceManifest name or the class of
-  # the ResourceManifest model_class to find.
-  #
-  # Returns a ResourceManifest if found, nil otherwise.
-  def self.find_resource_manifest(resource_name_or_klass)
-    resource_registry.find(resource_name_or_klass)
-  end
-
-  # Public: Stores the registry of components
-  def self.component_registry
-    @component_registry ||= ManifestRegistry.new(:components)
-  end
-
-  # Public: Stores the registry of participatory spaces
-  def self.participatory_space_registry
-    @participatory_space_registry ||= ManifestRegistry.new(:participatory_spaces)
-  end
-
   # Public: Stores the registry of reminders
   def self.reminders_registry
     @reminders_registry ||= ReminderRegistry.new
-  end
-
-  # Public: Stores the registry of resource spaces
-  def self.resource_registry
-    @resource_registry ||= ManifestRegistry.new(:resources)
-  end
-
-  # Public: Stores the registry of social shares services
-  def self.social_share_services_registry
-    @social_share_services_registry ||= ManifestRegistry.new(:social_share_services)
-  end
-
-  # Public: Stores the registry of notifications settings
-  def self.notification_settings_registry
-    @notification_settings_registry ||= ManifestRegistry.new(:notification_settings)
   end
 
   # Public: Stores the registry for user permissions


### PR DESCRIPTION
#### :tophat: What? Why?
This pull request refactors the registry logic in the `decidim-core` library by extracting the various registry-related methods into dedicated modules under `Decidim::Configuration`. These modules are then included in the main `Decidim` module, resulting in a cleaner and more modular codebase. The change removes the direct registry methods from `core.rb` and organizes them into separate files, improving maintainability and separation of concerns.

Key changes:

**Registry extraction and modularization:**

* Extracted component, participatory space, resource, global engine, notification settings, and social share service registry logic into separate modules under `decidim-core/lib/decidim/configuration/`.
* Updated `decidim-core/lib/decidim/core.rb` to autoload these new registry modules and include them in the main `Decidim` module.

**Removal of duplicated registry methods:**

* Removed the now-extracted registry methods and instance variables from `decidim-core/lib/decidim/core.rb`, delegating all such logic to the new modules.

This refactoring improves code organization and makes it easier to maintain and extend registry functionality in the future.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
